### PR TITLE
Remove macOS from testing pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest] # [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: same_content_newer
   test:
     needs: pre_test
     if: needs.pre_test.outputs.should_skip != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,16 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  pre_test:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
   test:
+    needs: pre_test
+    if: needs.pre_test.outputs.should_skip != 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
macOS runner minutes are expensive, and we don't even really care that much if it works on a Mac.