### PR TITLE
Add menu item to populate stream keys into vMix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "description": "AV Assistant application for FiM AV Voluenteers",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "us.fimav.assistant",
   "keywords": [
     "electron",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "description": "AV Assistant application for FiM AV Voluenteers",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "name": "us.fimav.assistant",
   "keywords": [
     "electron",

--- a/src/main/addons/autoav.ts
+++ b/src/main/addons/autoav.ts
@@ -96,11 +96,7 @@ export default class AutoAV {
         this.log('AutoAV Service Started');
 
         // Create new VMix Service
-        this.vmixService = new VmixRecordingService({
-            baseUrl: 'http://127.0.0.1:8000/api',
-            username: 'user',
-            password: 'pass',
-        });
+        this.vmixService = new VmixRecordingService();
 
         // Build a connection to the SignalR Hub
         this.hubConnection = new HubConnectionBuilder()

--- a/src/main/addons/hw-ping.ts
+++ b/src/main/addons/hw-ping.ts
@@ -83,38 +83,38 @@ export default class HWPing {
         let didUpdate = false;
         results.forEach((res, i) => {
             switch (i) {
-                case 0:
-                    if (this.currentState.switch !== res.alive) {
-                        this.currentState.switch = res.alive;
-                        didUpdate = true;
-                    }
-                    break;
-                case 1:
-                    if (this.currentState.mixer !== res.alive) {
-                        this.currentState.mixer = res.alive;
-                        didUpdate = true;
-                    }
-                    break;
-                case 2:
-                    if (this.currentState.camera1 !== res.alive) {
-                        this.currentState.camera1 = res.alive;
-                        didUpdate = true;
-                    }
-                    break;
-                case 3:
-                    if (this.currentState.camera2 !== res.alive) {
-                        this.currentState.camera2 = res.alive;
-                        didUpdate = true;
-                    }
-                    break;
-                case 4:
-                    if (this.currentState.internet !== res.alive) {
-                        this.currentState.internet = res.alive;
-                        didUpdate = true;
-                    }
-                    break;
-                default:
-                    break;
+            case 0:
+                if (this.currentState.switch !== res.alive) {
+                    this.currentState.switch = res.alive;
+                    didUpdate = true;
+                }
+                break;
+            case 1:
+                if (this.currentState.mixer !== res.alive) {
+                    this.currentState.mixer = res.alive;
+                    didUpdate = true;
+                }
+                break;
+            case 2:
+                if (this.currentState.camera1 !== res.alive) {
+                    this.currentState.camera1 = res.alive;
+                    didUpdate = true;
+                }
+                break;
+            case 3:
+                if (this.currentState.camera2 !== res.alive) {
+                    this.currentState.camera2 = res.alive;
+                    didUpdate = true;
+                }
+                break;
+            case 4:
+                if (this.currentState.internet !== res.alive) {
+                    this.currentState.internet = res.alive;
+                    didUpdate = true;
+                }
+                break;
+            default:
+                break;
             }
         });
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -7,6 +7,11 @@ export type AppConfig = {
     runOnStartup: boolean;
     currentStep: number;
     stepsStartedAt: number;
+    vmixApi: {
+        baseUrl: string;
+        username: string;
+        password: string
+    };
 };
 
 export function createStore(): Store<AppConfig> {
@@ -36,6 +41,23 @@ export function createStore(): Store<AppConfig> {
                 type: 'number',
                 default: 0,
             },
+            vmixApi: {
+                type: 'object',
+                properties: {
+                    baseUrl: {
+                        type: 'string',
+                        default: 'http://127.0.0.1:8000/api'
+                    },
+                    username: {
+                        type: 'string',
+                        default: 'user'
+                    },
+                    password: {
+                        type: 'string',
+                        default: 'pass'
+                    }
+                }
+            }
         },
         migrations: {
             '0.0.4': (store) => {
@@ -52,6 +74,13 @@ export function createStore(): Store<AppConfig> {
                 store.set('currentStep', 0);
                 store.set('stepsStartedAt', 0);
             },
+            '0.0.17': (store) => {
+                store.set('vmixApi', {
+                    baseUrl: 'http://127.0.0.1:8000/api',
+                    username: 'user',
+                    password: 'pass'
+                });
+            }
         },
     }) as Store<AppConfig>;
 }

--- a/src/main/window_components/menu.ts
+++ b/src/main/window_components/menu.ts
@@ -4,6 +4,7 @@ import {
     shell,
     BrowserWindow,
     MenuItemConstructorOptions,
+    dialog
 } from 'electron';
 import Addons from 'main/addons';
 import { platform } from 'os';
@@ -138,6 +139,31 @@ export default class MenuBuilder {
                     ],
                 },
                 {
+                    label: 'vMix',
+                    submenu: [
+                        {
+                            label: 'Set Stream Keys',
+                            click: async () => {
+                                try {
+                                    const service = new VmixService();
+                                    await service.SetStreamInfo();
+                                    dialog.showMessageBox({
+                                        message: 'Successfully set vMix streaming locations',
+                                        title: 'vMix Streaming',
+                                        type: 'info'
+                                    });
+                                } catch (e: any) {
+                                    dialog.showMessageBox({
+                                        message: `Failed to set streaming locations: ${e.toString()}`,
+                                        title: 'vMix Streaming',
+                                        type: 'info'
+                                    });
+                                }
+                            },
+                        },
+                    ],
+                },
+                {
                     label: 'About',
                     submenu: [
                         {
@@ -218,11 +244,7 @@ export default class MenuBuilder {
     }
 
     static async addLiveCapInput() {
-        const service = new VmixService({
-            baseUrl: 'http://127.0.0.1:8000/api',
-            username: 'user',
-            password: 'pass',
-        });
+        const service = new VmixService();
 
         try {
             // Add input to vMix

--- a/src/main/window_components/menu.ts
+++ b/src/main/window_components/menu.ts
@@ -92,12 +92,6 @@ export default class MenuBuilder {
                             label: 'Live Captions',
                             submenu: [
                                 {
-                                    label: 'Add input to vMix',
-                                    click() {
-                                        MenuBuilder.addLiveCapInput();
-                                    },
-                                },
-                                {
                                     label: 'Restart',
                                     click() {
                                         that.addons.restartLiveCaptions();
@@ -159,6 +153,12 @@ export default class MenuBuilder {
                                         type: 'info'
                                     });
                                 }
+                            },
+                        },
+                        {
+                            label: 'Add Live Captions input',
+                            click() {
+                                MenuBuilder.addLiveCapInput();
                             },
                         },
                     ],

--- a/src/services/VmixService.ts
+++ b/src/services/VmixService.ts
@@ -59,9 +59,11 @@ export default class VmixService {
         log.info('Setting stream info')
 
         const streamInfo: StreamInfo[] = await invokeExpectResponse('GetStreamInfo', 'StreamInfo');
+        log.info(streamInfo);
 
         const setStreamInfo = async (info: StreamInfo): Promise<void> => {
-            if (!info.rtmpUrl || !info.rtmpKey) return;
+            info.rtmpUrl ??= '';
+            info.rtmpKey ??= '';
 
             await fetch(`${this.settings.baseUrl}?Function=StreamingSetURL&Value=${info.index},${info.rtmpUrl}`, {
                 headers: this.createHeaders(),
@@ -71,7 +73,11 @@ export default class VmixService {
             });
         }
 
-        await Promise.all(streamInfo.map(setStreamInfo));
+        await Promise.all([0, 1, 2].map(idx => setStreamInfo(streamInfo.find(info => info.index === idx) ?? {
+            index: idx,
+            rtmpUrl: '',
+            rtmpKey: ''
+        })));
     }
 
     async AddBrowserInput(url: string): Promise<void> {

--- a/src/services/VmixService.ts
+++ b/src/services/VmixService.ts
@@ -1,3 +1,7 @@
+import log from 'electron-log';
+import { invokeExpectResponse } from "../main/window_components/signalR";
+import { getStore } from "../main/store";
+
 type VmixSettings = {
     baseUrl: string;
     username: string;
@@ -10,8 +14,12 @@ export default class VmixService {
     /**
      *
      */
-    constructor(settings: VmixSettings) {
-        this.settings = settings;
+    constructor(settings?: VmixSettings) {
+        if (settings) {
+            this.settings = settings;
+        } else {
+            this.settings = getStore().get('vmixApi');
+        }
     }
 
     updateSettings(settings: VmixSettings): void {
@@ -39,6 +47,31 @@ export default class VmixService {
         await fetch(`${this.settings.baseUrl}?Function=StopRecording`, {
             headers: this.createHeaders(),
         });
+    }
+
+    async SetStreamInfo(): Promise<void> {
+        type StreamInfo = {
+            index: number,
+            rtmpUrl: string,
+            rtmpKey: string
+        }
+
+        log.info('Setting stream info')
+
+        const streamInfo: StreamInfo[] = await invokeExpectResponse('GetStreamInfo', 'StreamInfo');
+
+        const setStreamInfo = async (info: StreamInfo): Promise<void> => {
+            if (!info.rtmpUrl || !info.rtmpKey) return;
+
+            await fetch(`${this.settings.baseUrl}?Function=StreamingSetURL&Value=${info.index},${info.rtmpUrl}`, {
+                headers: this.createHeaders(),
+            });
+            await fetch(`${this.settings.baseUrl}?Function=StreamingSetKey&Value=${info.index},${info.rtmpKey}`, {
+                headers: this.createHeaders(),
+            });
+        }
+
+        await Promise.all(streamInfo.map(setStreamInfo));
     }
 
     async AddBrowserInput(url: string): Promise<void> {


### PR DESCRIPTION
Note: All the requests into vMix are in parallel. I'm assuming that vMix can handle that, but we may need to run them in series if we get unexpected results

<img width="643" alt="image" src="https://github.com/FIRSTinMI/fimav-assistant/assets/3743825/b57d2fa1-1900-40a5-8e34-4dd291c62fc8">

Closes #25 #21 