### PR TITLE
Add vMix and Live Captions tabs, streaming/bandwidth monitoring, and Auto AV dead-time cutting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "description": "AV Assistant application for FiM AV Voluenteers",
-    "version": "2026.2.1",
+    "version": "2026.2.2",
     "name": "us.fimav.assistant",
     "keywords": [
         "electron",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "description": "AV Assistant application for FiM AV Voluenteers",
-    "version": "2026.2.2",
+    "version": "2026.3.0",
     "name": "us.fimav.assistant",
     "keywords": [
         "electron",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "us.fimav.assistant",
-    "version": "2026.1.7",
+    "version": "2026.3.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "us.fimav.assistant",
-            "version": "2026.1.7",
+            "version": "2026.3.10",
             "hasInstallScript": true,
             "license": "MIT"
         }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
     "description": "AV Assistant application for FiM AV Voluenteers",
-    "version": "2026.2.1",
+    "version": "2026.2.2",
     "name": "us.fimav.assistant",
     "keywords": [
         "electron",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
     "description": "AV Assistant application for FiM AV Voluenteers",
-    "version": "2026.2.2",
+    "version": "2026.3.0",
     "name": "us.fimav.assistant",
     "keywords": [
         "electron",

--- a/src/main/addons/autoav.ts
+++ b/src/main/addons/autoav.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import path from 'path';
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 import nodeFetch from 'node-fetch';
 import log from 'electron-log';
@@ -8,12 +9,21 @@ import {
     EquipmentLogType,
 } from '../../models/EquipmentLog';
 import FMSMatchStatus from '../../models/FMSMatchState';
-import attemptRename from '../../utils/recording';
+import attemptRename, { FileNameMode } from '../../utils/recording';
 import { AddonLoggers } from './addon-loggers';
 import { getCurrentEvent, signalrToElectronLog } from '../util';
 import VmixService from '../../services/VmixService';
+import FmsApi from '../../services/FmsApi';
 import Event from '../../models/Event';
+import { AutoAVStatus } from '../../models/AutoAVStatus';
+import { MatchRecord } from '../../models/MatchRecord';
+import { upsertMatch, updateMatch } from '../recordings/matchStore';
+import { getStore } from '../store';
 import { invokeExpectResponse, invokeLog } from '../window_components/signalR';
+
+// Events AutoAV emits to the renderer: a human status line, a structured
+// status snapshot, and match-record upserts.
+export type AutoAVEvent = 'info' | 'status' | 'match';
 
 export default class AutoAV {
     private static instance: AutoAV;
@@ -45,6 +55,23 @@ export default class AutoAV {
     // Event Emitter
     private emitter: EventEmitter = new EventEmitter();
 
+    // Structured status surfaced to the Auto AV tab
+    private status: AutoAVStatus = {
+        fmsConnected: false,
+        vmix: { reachable: false, recording: false },
+        recordingActive: false,
+        currentEvent: null,
+        saveFolder: null,
+        fileNameMode: 'in-season',
+        lastMessage: null,
+    };
+
+    // Id of the MatchRecord for the in-progress recording, so we can patch it on stop
+    private currentRecordId: string | null = null;
+
+    // Periodic vMix reachability poll
+    private vmixPollTimer: ReturnType<typeof setInterval> | null = null;
+
     constructor() {
         // Start new log files
         this.logs = {
@@ -73,9 +100,16 @@ export default class AutoAV {
                 this.logRecording('🟥 Stopped Recording');
                 this.weAreRecording = false;
                 this.willStopRecording = false;
+                this.status.recordingActive = false;
+                this.status.vmix.recording = false;
+                this.emitStatus();
 
                 // If we don't have a start time or data, don't try to rename
                 if (!this.lastMatchStartData) return undefined;
+
+                // Keep a local handle; the fields below get reset in finally
+                const matchData = this.lastMatchStartData;
+                const recordId = this.currentRecordId;
 
                 // If we don't have an event name, try to get it
                 if (!this.currentEvent) {
@@ -85,6 +119,7 @@ export default class AutoAV {
                         EquipmentLogType.Warn
                     );
                     this.currentEvent = await this.fetchEvent();
+                    this.emitStatus();
                 }
 
                 // Attempt to rename the file
@@ -92,18 +127,46 @@ export default class AutoAV {
                     const filename = await attemptRename(
                         this.currentEvent,
                         this.currentFile,
-                        this.lastMatchStartData
+                        matchData
                     );
 
                     this.logRecording(`Renamed last recording to ${filename}`);
+
+                    // Patch the record with its final location
+                    if (recordId) {
+                        const saveFolder = path.dirname(filename);
+                        this.status.saveFolder = saveFolder;
+                        const record = updateMatch(recordId, {
+                            fileName: path.basename(filename),
+                            filePath: filename,
+                            saveFolder,
+                            endedAt: Date.now(),
+                            status: 'recorded',
+                        });
+                        if (record) this.emitter.emit('match', record);
+                        this.emitStatus();
+
+                        // Best-effort metadata capture (teams + cards). Runs
+                        // after the rename so a failed fetch never risks the file.
+                        this.captureMetadata(recordId, matchData);
+                    }
                 } catch (err: any) {
                     this.logRecording(
                         `‼️ Error Renaming Recording`,
                         err,
                         EquipmentLogType.Error
                     );
+                    if (recordId) {
+                        const record = updateMatch(recordId, {
+                            status: 'error',
+                            error: String(err?.message ?? err),
+                            endedAt: Date.now(),
+                        });
+                        if (record) this.emitter.emit('match', record);
+                    }
                 } finally {
                     this.lastMatchStartData = null;
+                    this.currentRecordId = null;
                 }
 
                 return undefined;
@@ -130,6 +193,30 @@ export default class AutoAV {
                 this.lastMatchStartData = matchInfo;
                 this.weAreRecording = true;
 
+                // Create a record for this match so it shows in the Auto AV tab
+                const startedAt = Date.now();
+                const record: MatchRecord = {
+                    id: `${matchInfo.Level}_${matchInfo.MatchNumber}_${matchInfo.PlayNumber}_${startedAt}`,
+                    level: matchInfo.Level,
+                    matchNumber: matchInfo.MatchNumber,
+                    playNumber: matchInfo.PlayNumber,
+                    eventName: this.currentEvent?.name ?? 'Unknown Event',
+                    eventCode: this.currentEvent?.code ?? null,
+                    fileName: null,
+                    filePath: null,
+                    saveFolder: null,
+                    startedAt,
+                    endedAt: null,
+                    status: 'recording',
+                };
+                this.currentRecordId = record.id;
+                upsertMatch(record);
+                this.emitter.emit('match', record);
+
+                this.status.recordingActive = true;
+                this.status.vmix.recording = true;
+                this.emitStatus();
+
                 // Give it some time, then attempt to find the file
                 setTimeout(async () => {
                     this.currentFile =
@@ -151,6 +238,9 @@ export default class AutoAV {
     public start() {
         // Notify Parent logs that we're running
         this.log('AutoAV Service Started', undefined, true);
+
+        // Begin polling vMix reachability for the status tab
+        this.startVmixPoll();
 
         // Build a connection to the SignalR Hub
         this.hubConnection = new HubConnectionBuilder()
@@ -276,6 +366,8 @@ export default class AutoAV {
 
         // Register connected/disconnected events
         this.hubConnection.onreconnecting(() => {
+            this.status.fmsConnected = false;
+            this.emitStatus();
             this.logFMS(
                 'AutoAV FMS Connection Lost, Reconnecting',
                 undefined,
@@ -283,7 +375,13 @@ export default class AutoAV {
                 true
             );
         });
+        this.hubConnection.onreconnected(() => {
+            this.status.fmsConnected = true;
+            this.emitStatus();
+        });
         this.hubConnection.onclose(() => {
+            this.status.fmsConnected = false;
+            this.emitStatus();
             this.logFMS(
                 'AutoAV FMS Connection Closed!',
                 undefined,
@@ -296,6 +394,8 @@ export default class AutoAV {
         this.hubConnection
             .start()
             .then(() => {
+                this.status.fmsConnected = true;
+                this.emitStatus();
                 this.logFMS(
                     'FMS Connection Established!',
                     undefined,
@@ -306,6 +406,8 @@ export default class AutoAV {
                 return undefined;
             })
             .catch((err) => {
+                this.status.fmsConnected = false;
+                this.emitStatus();
                 this.logFMS(
                     `AutoAV FMS Connection Failed. Restarting...`,
                     err,
@@ -326,6 +428,11 @@ export default class AutoAV {
         // Log stopping
         this.log('AutoAV Service Stopped');
         this.emitter.emit('info', 'Service Stopped');
+        // Stop polling vMix
+        this.stopVmixPoll();
+        this.status.fmsConnected = false;
+        this.status.vmix = { reachable: false, recording: false };
+        this.emitStatus();
         // Stop the SignalR Hub connection
         this.hubConnection?.stop();
     }
@@ -434,7 +541,9 @@ export default class AutoAV {
 
         // Log to frontend
         if (notifyClient) {
+            this.status.lastMessage = msg;
             this.emitter.emit('info', msg);
+            this.emitStatus();
         }
 
         // Don't send debug to logging server, too verbose
@@ -455,6 +564,104 @@ export default class AutoAV {
     // Set the event name
     public setEvent(event: Event | null) {
         this.currentEvent = event;
+        this.emitStatus();
+    }
+
+    // Effective file naming mode: official events are always in-season,
+    // unofficial always off-season, otherwise fall back to the stored setting.
+    private effectiveFileNameMode(): FileNameMode {
+        if (this.currentEvent?.isOfficial === false) return 'off-season';
+        if (this.currentEvent?.isOfficial === true) return 'in-season';
+        return getStore().get('autoAv.fileNameMode', 'in-season');
+    }
+
+    // Build and broadcast the current status snapshot
+    private emitStatus() {
+        this.status.currentEvent = this.currentEvent
+            ? {
+                  name: this.currentEvent.name,
+                  code: this.currentEvent.code ?? null,
+              }
+            : null;
+        this.status.fileNameMode = this.effectiveFileNameMode();
+        this.emitter.emit('status', this.getStatus());
+    }
+
+    // Current status snapshot (for IPC getState)
+    public getStatus(): AutoAVStatus {
+        return {
+            ...this.status,
+            vmix: { ...this.status.vmix },
+            currentEvent: this.status.currentEvent
+                ? { ...this.status.currentEvent }
+                : null,
+        };
+    }
+
+    // Poll vMix so the tab can show whether it's reachable / recording
+    private startVmixPoll() {
+        this.stopVmixPoll();
+        this.vmixPollTimer = setInterval(() => this.pollVmix(), 5000);
+        this.pollVmix();
+    }
+
+    private stopVmixPoll() {
+        if (this.vmixPollTimer) {
+            clearInterval(this.vmixPollTimer);
+            this.vmixPollTimer = null;
+        }
+    }
+
+    private async pollVmix() {
+        let reachable = false;
+        let recording = false;
+        try {
+            const parsed = await VmixService.Instance.GetBase();
+            reachable = !!parsed?.vmix;
+            recording = parsed?.vmix?.recording?.['#text'] === 'True';
+        } catch {
+            reachable = false;
+            recording = false;
+        }
+        if (
+            this.status.vmix.reachable !== reachable ||
+            this.status.vmix.recording !== recording
+        ) {
+            this.status.vmix = { reachable, recording };
+            this.emitStatus();
+        }
+    }
+
+    // Best-effort fetch of teams + card status for a finished match, patched
+    // onto the record after it's been renamed. Never throws into the stop path.
+    private async captureMetadata(recordId: string, matchData: FMSMatchStatus) {
+        try {
+            const results = await FmsApi.Instance.getMatchResults(
+                matchData.Level,
+                matchData.MatchNumber
+            );
+            if (!results) return;
+            const record = updateMatch(recordId, {
+                teams: results.teams,
+                hasCard: results.hasCard,
+            });
+            if (record) {
+                this.emitter.emit('match', record);
+                this.logRecording(
+                    `Captured metadata for ${matchData.Level} Match ${
+                        matchData.MatchNumber
+                    }${results.hasCard ? ' (card issued)' : ''}`,
+                    undefined,
+                    EquipmentLogType.Debug
+                );
+            }
+        } catch (err) {
+            this.logRecording(
+                'Failed to capture match metadata',
+                err as object,
+                EquipmentLogType.Warn
+            );
+        }
     }
 
     public static get Instance(): AutoAV {
@@ -463,17 +670,17 @@ export default class AutoAV {
     }
 
     // eslint-disable-next-line no-unused-vars
-    public on(event: 'info', listener: (arg: string) => void) {
+    public on(event: AutoAVEvent, listener: (arg: any) => void) {
         this.emitter.on(event, listener);
     }
 
     // eslint-disable-next-line no-unused-vars
-    public off(event: 'info', listener: (arg: string) => void) {
+    public off(event: AutoAVEvent, listener: (arg: any) => void) {
         this.emitter.off(event, listener);
     }
 
     // eslint-disable-next-line no-unused-vars
-    public once(event: 'info', listener: (arg: string) => void) {
+    public once(event: AutoAVEvent, listener: (arg: any) => void) {
         this.emitter.once(event, listener);
     }
 }

--- a/src/main/addons/autoav.ts
+++ b/src/main/addons/autoav.ts
@@ -1,5 +1,7 @@
 import EventEmitter from 'events';
 import path from 'path';
+import fs from 'fs';
+import glob from 'glob';
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 import nodeFetch from 'node-fetch';
 import log from 'electron-log';
@@ -9,7 +11,11 @@ import {
     EquipmentLogType,
 } from '../../models/EquipmentLog';
 import FMSMatchStatus from '../../models/FMSMatchState';
-import attemptRename, { FileNameMode } from '../../utils/recording';
+import attemptRename, {
+    FileNameMode,
+    eventFolderName,
+    sampleFileName,
+} from '../../utils/recording';
 import { AddonLoggers } from './addon-loggers';
 import { getCurrentEvent, signalrToElectronLog } from '../util';
 import VmixService from '../../services/VmixService';
@@ -17,13 +23,20 @@ import FmsApi from '../../services/FmsApi';
 import Event from '../../models/Event';
 import { AutoAVStatus } from '../../models/AutoAVStatus';
 import { MatchRecord } from '../../models/MatchRecord';
-import { upsertMatch, updateMatch } from '../recordings/matchStore';
+import {
+    upsertMatch,
+    updateMatch,
+    getMatch,
+    listMatches,
+} from '../recordings/matchStore';
+import cutMatchVideo, { enqueueCut } from '../cutMatch';
 import { getStore } from '../store';
 import { invokeExpectResponse, invokeLog } from '../window_components/signalR';
 
 // Events AutoAV emits to the renderer: a human status line, a structured
-// status snapshot, and match-record upserts.
-export type AutoAVEvent = 'info' | 'status' | 'match';
+// status snapshot, a single match-record upsert, and the full match list for
+// the current event folder.
+export type AutoAVEvent = 'info' | 'status' | 'match' | 'matches';
 
 export default class AutoAV {
     private static instance: AutoAV;
@@ -57,20 +70,31 @@ export default class AutoAV {
 
     // Structured status surfaced to the Auto AV tab
     private status: AutoAVStatus = {
+        running: false,
         fmsConnected: false,
         vmix: { reachable: false, recording: false },
         recordingActive: false,
         currentEvent: null,
         saveFolder: null,
         fileNameMode: 'in-season',
+        sampleFileName: '',
         lastMessage: null,
     };
 
     // Id of the MatchRecord for the in-progress recording, so we can patch it on stop
     private currentRecordId: string | null = null;
 
+    // The in-progress record itself. It isn't persisted until the recording
+    // stops (we don't know the destination folder for its manifest until then),
+    // so we hold it here and write it once the file is filed.
+    private currentRecordObj: MatchRecord | null = null;
+
     // Periodic vMix reachability poll
     private vmixPollTimer: ReturnType<typeof setInterval> | null = null;
+
+    // vMix's configured recording folder, cached from the poll so emitStatus can
+    // show the exact save path before the first recording.
+    private vmixRecordFolder: string | null = null;
 
     constructor() {
         // Start new log files
@@ -132,23 +156,41 @@ export default class AutoAV {
 
                     this.logRecording(`Renamed last recording to ${filename}`);
 
-                    // Patch the record with its final location
-                    if (recordId) {
+                    // Persist the finished record into the manifest that lives
+                    // in the event folder the file was filed into.
+                    if (recordId && this.currentRecordObj) {
                         const saveFolder = path.dirname(filename);
                         this.status.saveFolder = saveFolder;
-                        const record = updateMatch(recordId, {
+                        const record: MatchRecord = {
+                            ...this.currentRecordObj,
                             fileName: path.basename(filename),
                             filePath: filename,
                             saveFolder,
                             endedAt: Date.now(),
                             status: 'recorded',
-                        });
-                        if (record) this.emitter.emit('match', record);
+                        };
+                        upsertMatch(saveFolder, record);
+                        this.emitter.emit('match', record);
                         this.emitStatus();
 
-                        // Best-effort metadata capture (teams + cards). Runs
-                        // after the rename so a failed fetch never risks the file.
-                        this.captureMetadata(recordId, matchData);
+                        // Capture teams + cards first, so the card rule below can
+                        // be honoured. Best-effort: a failed fetch never risks
+                        // the file, and only means we can't confirm cards.
+                        const hasCard = await this.captureMetadata(
+                            saveFolder,
+                            recordId,
+                            matchData
+                        );
+
+                        // Auto-cut the dead time in place (original moved to
+                        // Originals/), if enabled. Never cut a match with a card:
+                        // the card explanation lives in the dead time we'd remove.
+                        if (
+                            getStore().get('autoAv.autoCut', false) &&
+                            hasCard !== true
+                        ) {
+                            this.queueCut(saveFolder, recordId);
+                        }
                     }
                 } catch (err: any) {
                     this.logRecording(
@@ -156,17 +198,25 @@ export default class AutoAV {
                         err,
                         EquipmentLogType.Error
                     );
-                    if (recordId) {
-                        const record = updateMatch(recordId, {
+                    // The file was never filed, so there's no folder/manifest to
+                    // write to. Persist the error record if we have a folder,
+                    // else just surface it live.
+                    if (recordId && this.currentRecordObj) {
+                        const errored: MatchRecord = {
+                            ...this.currentRecordObj,
                             status: 'error',
                             error: String(err?.message ?? err),
                             endedAt: Date.now(),
-                        });
-                        if (record) this.emitter.emit('match', record);
+                        };
+                        if (this.status.saveFolder) {
+                            upsertMatch(this.status.saveFolder, errored);
+                        }
+                        this.emitter.emit('match', errored);
                     }
                 } finally {
                     this.lastMatchStartData = null;
                     this.currentRecordId = null;
+                    this.currentRecordObj = null;
                 }
 
                 return undefined;
@@ -210,7 +260,10 @@ export default class AutoAV {
                     status: 'recording',
                 };
                 this.currentRecordId = record.id;
-                upsertMatch(record);
+                this.currentRecordObj = record;
+                // Not persisted yet: the destination folder (and thus which
+                // manifest to write) isn't known until the file is filed on
+                // stop. Emit it live so the tab shows it recording.
                 this.emitter.emit('match', record);
 
                 this.status.recordingActive = true;
@@ -238,6 +291,9 @@ export default class AutoAV {
     public start() {
         // Notify Parent logs that we're running
         this.log('AutoAV Service Started', undefined, true);
+
+        this.status.running = true;
+        this.emitStatus();
 
         // Begin polling vMix reachability for the status tab
         this.startVmixPoll();
@@ -430,6 +486,7 @@ export default class AutoAV {
         this.emitter.emit('info', 'Service Stopped');
         // Stop polling vMix
         this.stopVmixPoll();
+        this.status.running = false;
         this.status.fmsConnected = false;
         this.status.vmix = { reachable: false, recording: false };
         this.emitStatus();
@@ -567,6 +624,15 @@ export default class AutoAV {
         this.emitStatus();
     }
 
+    // Apply settings changed from the Auto AV settings dialog: re-emit status
+    // (picks up a new naming mode) and re-check vMix with the new connection.
+    public applySettings(): void {
+        this.emitStatus();
+        // The save folder may have changed, so refresh the history to match.
+        this.emitMatches();
+        this.pollVmix();
+    }
+
     // Effective file naming mode: official events are always in-season,
     // unofficial always off-season, otherwise fall back to the stored setting.
     private effectiveFileNameMode(): FileNameMode {
@@ -577,13 +643,49 @@ export default class AutoAV {
 
     // Build and broadcast the current status snapshot
     private emitStatus() {
-        this.status.currentEvent = this.currentEvent
+        const store = getStore();
+        const nameOverride = store.get('autoAv.eventNameOverride', '').trim();
+        const saveFolderOverride = store.get('autoAv.saveFolder', '').trim();
+
+        // The event actually used for naming: a typed override always wins.
+        const effectiveEvent: Event | null = nameOverride
+            ? ({
+                  ...(this.currentEvent ?? {}),
+                  name: nameOverride,
+                  code: nameOverride,
+              } as Event)
+            : this.currentEvent;
+
+        this.status.currentEvent = effectiveEvent
             ? {
-                  name: this.currentEvent.name,
-                  code: this.currentEvent.code ?? null,
+                  name: effectiveEvent.name,
+                  code: effectiveEvent.code ?? null,
               }
             : null;
         this.status.fileNameMode = this.effectiveFileNameMode();
+        this.status.sampleFileName = sampleFileName(
+            effectiveEvent,
+            this.status.fileNameMode
+        );
+
+        // Effective destination folder = base folder + the event subfolder for
+        // the CURRENT effective event name. The event subfolder is always
+        // recomputed from the name (not frozen to the last recording), so
+        // changing the event name updates the shown path immediately. The base
+        // is: an explicit save-folder override, else the parent of the last real
+        // save folder, else vMix's configured record folder.
+        let base: string | null = null;
+        if (saveFolderOverride) {
+            base = saveFolderOverride;
+        } else {
+            const last = store.get('autoAv.lastSaveFolder', '').trim();
+            if (last) base = path.dirname(last);
+            else if (this.vmixRecordFolder) base = this.vmixRecordFolder;
+        }
+        this.status.saveFolder = base
+            ? path.join(base, eventFolderName(effectiveEvent))
+            : null;
+
         this.emitter.emit('status', this.getStatus());
     }
 
@@ -612,36 +714,95 @@ export default class AutoAV {
         }
     }
 
+    // Read vMix's configured recording folder from its .NET user.config (the
+    // Web API only reports it while actively recording). Safe heuristic: a
+    // setting whose NAME contains "record" whose value is an existing directory.
+    // Returns null rather than a wrong guess.
+    private static readVmixConfigRecordFolder(): string | null {
+        try {
+            const base = path.join(
+                process.env.LOCALAPPDATA || '',
+                'vMix'
+            );
+            const files = glob
+                .sync(path.join(base, 'vMix*', '*', 'user.config'))
+                .map((f) => ({ f, m: fs.statSync(f).mtimeMs }))
+                .sort((a, b) => b.m - a.m);
+            let found: string | null = null;
+            files.forEach(({ f }) => {
+                if (found !== null) return;
+                const xml = fs.readFileSync(f, 'utf8');
+                const re =
+                    /<setting name="[^"]*record[^"]*"[^>]*>\s*<value>([A-Za-z]:\\[^<]+?)<\/value>/gi;
+                const hit = [...xml.matchAll(re)]
+                    .map((m) => m[1].trim())
+                    .find((dir) => fs.existsSync(dir));
+                if (hit) found = hit;
+            });
+            return found;
+        } catch {
+            // best effort
+        }
+        return null;
+    }
+
     private async pollVmix() {
         let reachable = false;
         let recording = false;
+        let recordFolder: string | null = this.vmixRecordFolder;
         try {
             const parsed = await VmixService.Instance.GetBase();
             reachable = !!parsed?.vmix;
             recording = parsed?.vmix?.recording?.['#text'] === 'True';
+            // vMix reports the record destination as recording.filename1, but
+            // only while actively recording. When idle, fall back to reading its
+            // config file.
+            const file =
+                parsed?.vmix?.recording?.filename1 ??
+                parsed?.vmix?.recording?.filename;
+            if (typeof file === 'string' && file.trim()) {
+                const i = Math.max(
+                    file.lastIndexOf('\\'),
+                    file.lastIndexOf('/')
+                );
+                recordFolder = i > 0 ? file.slice(0, i) : file;
+            } else if (!recordFolder) {
+                recordFolder = AutoAV.readVmixConfigRecordFolder();
+            }
         } catch {
             reachable = false;
             recording = false;
         }
+        const folderChanged = recordFolder !== this.vmixRecordFolder;
+        if (folderChanged) this.vmixRecordFolder = recordFolder;
         if (
             this.status.vmix.reachable !== reachable ||
-            this.status.vmix.recording !== recording
+            this.status.vmix.recording !== recording ||
+            folderChanged
         ) {
             this.status.vmix = { reachable, recording };
             this.emitStatus();
+            // A changed record folder means a different event: refresh history.
+            if (folderChanged) this.emitMatches();
         }
     }
 
     // Best-effort fetch of teams + card status for a finished match, patched
     // onto the record after it's been renamed. Never throws into the stop path.
-    private async captureMetadata(recordId: string, matchData: FMSMatchStatus) {
+    // Returns the card status: true (carded), false (clean), or undefined when
+    // it couldn't be determined, so the caller can honour the no-cut card rule.
+    private async captureMetadata(
+        folder: string,
+        recordId: string,
+        matchData: FMSMatchStatus
+    ): Promise<boolean | undefined> {
         try {
             const results = await FmsApi.Instance.getMatchResults(
                 matchData.Level,
                 matchData.MatchNumber
             );
-            if (!results) return;
-            const record = updateMatch(recordId, {
+            if (!results) return undefined;
+            const record = updateMatch(folder, recordId, {
                 teams: results.teams,
                 hasCard: results.hasCard,
             });
@@ -655,13 +816,111 @@ export default class AutoAV {
                     EquipmentLogType.Debug
                 );
             }
+            return results.hasCard;
         } catch (err) {
             this.logRecording(
                 'Failed to capture match metadata',
                 err as object,
                 EquipmentLogType.Warn
             );
+            return undefined;
         }
+    }
+
+    // Cut the dead time out of a recorded match in place: the original video is
+    // moved into an "Originals" subfolder and the trimmed, upload-ready cut takes
+    // its spot in the base event folder (so the base folder holds every match's
+    // final video, cut and uncut alike). Queued so a burst of matches encodes one
+    // at a time and never starves vMix/streaming of CPU. Best-effort: a failure
+    // restores the original and only marks the record. Refuses carded matches so
+    // their explanation (which lives in the dead time) is preserved. Used by both
+    // the auto-cut path and the manual Cut button.
+    public queueCut(folder: string, recordId: string): void {
+        const rec = getMatch(folder, recordId);
+        if (!rec || !rec.filePath) return;
+        if (rec.hasCard) {
+            this.logRecording(
+                `Not cutting ${rec.fileName} (card issued, keeping explanation)`,
+                undefined,
+                EquipmentLogType.Debug
+            );
+            return;
+        }
+        const state = rec.processing?.state;
+        if (state === 'queued' || state === 'processing') return;
+
+        const mainPath = rec.filePath;
+        const originalsDir = path.join(folder, 'Originals');
+        const originalPath = path.join(originalsDir, path.basename(mainPath));
+
+        const queued = updateMatch(folder, recordId, {
+            processing: { state: 'queued' },
+        });
+        if (queued) this.emitter.emit('match', queued);
+
+        enqueueCut(async () => {
+            try {
+                if (!fs.existsSync(originalsDir)) {
+                    fs.mkdirSync(originalsDir, { recursive: true });
+                }
+                const started = updateMatch(folder, recordId, {
+                    processing: { state: 'processing' },
+                });
+                if (started) this.emitter.emit('match', started);
+                this.logRecording(`Cutting ${path.basename(mainPath)}`);
+
+                // Move the original aside (don't clobber an existing Originals
+                // copy from a prior attempt), then cut it back into the base spot.
+                if (fs.existsSync(mainPath) && !fs.existsSync(originalPath)) {
+                    fs.renameSync(mainPath, originalPath);
+                }
+                const source = fs.existsSync(originalPath)
+                    ? originalPath
+                    : mainPath;
+                await cutMatchVideo(source, mainPath);
+
+                const done = updateMatch(folder, recordId, {
+                    processing: { state: 'done', outputPath: mainPath },
+                });
+                if (done) this.emitter.emit('match', done);
+                this.logRecording(
+                    `Cut ${path.basename(mainPath)}; original kept in Originals`,
+                    undefined,
+                    EquipmentLogType.Debug
+                );
+            } catch (err: any) {
+                // Restore the original to the base folder if the cut left it
+                // missing, so we never lose the recording.
+                try {
+                    if (
+                        !fs.existsSync(mainPath) &&
+                        fs.existsSync(originalPath)
+                    ) {
+                        fs.renameSync(originalPath, mainPath);
+                    }
+                } catch {
+                    // best effort
+                }
+                const failed = updateMatch(folder, recordId, {
+                    processing: {
+                        state: 'error',
+                        error: String(err?.message ?? err),
+                    },
+                });
+                if (failed) this.emitter.emit('match', failed);
+                this.logRecording(
+                    'Failed to cut recording',
+                    err as object,
+                    EquipmentLogType.Warn
+                );
+            }
+        });
+    }
+
+    // Emit the recorded-match list for the folder the app is currently pointed
+    // at, so the tab's history reflects the current event folder.
+    public emitMatches(): void {
+        this.emitter.emit('matches', listMatches(this.status.saveFolder));
     }
 
     public static get Instance(): AutoAV {

--- a/src/main/addons/live-captions.ts
+++ b/src/main/addons/live-captions.ts
@@ -14,6 +14,9 @@ export default class LiveCaptions {
 
     private running = false;
 
+    // Version of the live-captions build currently launched, surfaced in the tab
+    private currentVersion = '0.0.0';
+
     private process: ChildProcessWithoutNullStreams | null = null;
 
     private logs: AddonLoggers;
@@ -25,32 +28,95 @@ export default class LiveCaptions {
         };
     }
 
-    // Kill any existing live-captions processes
+    // The port live-captions serves its UI/API on.
+    private static readonly PORT = 3000;
+
+    // Kill EVERY live-captions process, tracked or orphaned, by BOTH image name
+    // and by whatever is holding port 3000. The port sweep is the belt-and-
+    // suspenders half: even if a process got renamed, wedged, or was spawned by
+    // a previous app version, freeing the port guarantees the next start can
+    // actually bind. This is why the blank screen kept coming back - a leftover
+    // instance held 3000, the new one hit EADDRINUSE, and live-captions swallows
+    // that exception and sits there serving nothing.
     private killExisting() {
+        // 1) Kill by image name. The taskkill /FI "IMAGENAME eq name*.exe"
+        // wildcard filter is rejected on some Win11 builds ("search filter
+        // cannot be recognized"), so enumerate with tasklist and kill by PID.
         try {
-            // Find any exiting live-captions processes and kill them
-            const out = execSync(
-                'wmic process get processid,name | find "live-captions"'
-            ).toString(); // outputs "<process name>                    <pid>"
-            const lines = out.split('\n');
-            if (lines.length > 1) {
-                const split = lines[0].trim().split(' ');
-                const pid = split[split.length - 1];
-                this.logs.out.log(
-                    `Found existing live-captions process (PID ${pid}), killing it`
+            const tl = execSync('tasklist /fo csv /nh').toString();
+            tl.split(/\r?\n/).forEach((line) => {
+                const m = /^"(live-captions[^"]*\.exe)","(\d+)"/i.exec(
+                    line.trim()
                 );
-                execSync(`taskkill /pid ${pid} /f /t`);
-            }
-        } catch (err) {
-            // Ignore any errors
-            this.logs.out.warn(
-                'Unable to stop existing live captions processes',
-                err
-            );
-        } finally {
-            this.running = false;
-            this.process = null;
+                if (m) {
+                    try {
+                        execSync(`taskkill /F /T /PID ${m[2]}`, {
+                            stdio: 'ignore',
+                        });
+                    } catch {
+                        // already gone
+                    }
+                }
+            });
+        } catch {
+            // tasklist unavailable (non-Windows dev box) - ignore.
         }
+
+        // 2) Kill whatever is still LISTENING on the port, whatever it's called.
+        try {
+            const out = execSync('netstat -ano -p tcp').toString();
+            const pids = new Set<string>();
+            out.split(/\r?\n/).forEach((line) => {
+                if (
+                    line.includes(`:${LiveCaptions.PORT} `) ||
+                    line.includes(`:${LiveCaptions.PORT}\t`)
+                ) {
+                    const cols = line.trim().split(/\s+/);
+                    const pid = cols[cols.length - 1];
+                    if (/^\d+$/.test(pid) && pid !== '0') pids.add(pid);
+                }
+            });
+            pids.forEach((pid) => {
+                try {
+                    execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'ignore' });
+                    this.logs.out.log(
+                        `Freed port ${LiveCaptions.PORT} (killed PID ${pid})`
+                    );
+                } catch {
+                    // ignore
+                }
+            });
+        } catch {
+            // netstat unavailable (non-Windows dev box) - ignore.
+        }
+
+        this.running = false;
+        this.process = null;
+    }
+
+    // Poll the live-captions HTTP server until it actually answers, so we only
+    // report "running" once it's really serving (not just that the process
+    // spawned). Returns false if it never comes up within the timeout.
+    // eslint-disable-next-line class-methods-use-this
+    private async waitForServer(timeoutMs = 12000): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                const res = await fetch(
+                    `http://127.0.0.1:${LiveCaptions.PORT}/`,
+                    { signal: AbortSignal.timeout(1500) }
+                );
+                if (res.ok || res.status < 500) return true;
+            } catch {
+                // not up yet
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((resolve) => {
+                setTimeout(resolve, 500);
+            });
+        }
+        return false;
     }
 
     /*
@@ -72,42 +138,52 @@ export default class LiveCaptions {
             }
         });
 
-        const baseUrl = getStore().get('liveCaptionsDownloadBase');
+        // Update check + download is best-effort: if we're offline (e.g. at a
+        // venue) or the download fails, fall back to the newest local exe rather
+        // than throwing and leaving live-captions down.
+        try {
+            const baseUrl = getStore().get('liveCaptionsDownloadBase');
+            const res = await fetch(`${baseUrl}/latest`, {
+                signal: AbortSignal.timeout(8000),
+            });
+            // "/latest" forwards to the newest release URL; extract its version.
+            const latestVersion = res.url.split('/').pop()?.slice(1) || '0.0.0';
 
-        // If it doesn't exist, download it from Github
-        const res = await fetch(`${baseUrl}/latest`);
-
-        // Fetching "/latest" from github forwards to the latest release URL, which we can then extract the version from the response URL.
-        const latestVersion = res.url.split('/').pop()?.slice(1) || '0.0.0';
-
-        // If the latest version is greater than the current version, download the latest version
-        if (latestVersion > currentVersion) {
-            this.logs.out.log(
-                `Found new version of live-captions, currently at ${currentVersion}, downloading ${latestVersion}`
+            if (latestVersion > currentVersion) {
+                this.logs.out.log(
+                    `Found new version of live-captions, currently at ${currentVersion}, downloading ${latestVersion}`
+                );
+                const target = path.join(
+                    appdataPath,
+                    `live-captions-${latestVersion}.exe`
+                );
+                const stream = fs.createWriteStream(target);
+                const { body } = await fetch(
+                    `${baseUrl}/download/v${latestVersion}/live-captions-${latestVersion}.exe`
+                );
+                if (body === null)
+                    throw new Error('Failed to download live-captions');
+                // @ts-ignore
+                await finished(Readable.fromWeb(body).pipe(stream));
+                currentVersion = latestVersion;
+            }
+        } catch (e) {
+            this.logs.err.warn(
+                `Update check failed, using local v${currentVersion}`,
+                e
             );
+        }
 
-            // Create write stream
-            const stream = fs.createWriteStream(
-                path.join(appdataPath, `live-captions-${latestVersion}.exe`)
+        if (currentVersion === '0.0.0') {
+            this.logs.err.error(
+                'No live-captions executable available (never downloaded and offline)'
             );
-
-            // Download the live-captions executable
-            const { body } = await fetch(
-                `${baseUrl}/download/v${latestVersion}/live-captions-${latestVersion}.exe`
-            );
-
-            // Check if the download was successful
-            if (body === null)
-                throw new Error('Failed to download live-captions');
-
-            // @ts-ignore
-            await finished(Readable.fromWeb(body).pipe(stream));
-
-            // Update current version
-            currentVersion = latestVersion;
+            this.running = false;
+            return false;
         }
 
         this.logs.out.log(`Starting live-captions v${currentVersion}`);
+        this.currentVersion = currentVersion;
 
         // Start the live-captions process
         return this.startLiveCaptions(
@@ -115,56 +191,114 @@ export default class LiveCaptions {
         );
     }
 
-    // Stop the live-captions process
+    // Stop live-captions. Kills EVERY instance (tracked or orphaned), not just
+    // the one we spawned, so a lost background child can't keep holding port
+    // 3000. This is what the Stop button and the pre-launch cleanup both need.
+    // Exit handlers are identity-guarded, so the kill firing exit is harmless.
     public stop(): Promise<boolean> {
         return new Promise<boolean>((resolve) => {
-            if (!this.running || !this.process || this.process.killed) {
-                resolve(true);
-                return;
-            }
-
-            // Remove the exit listener
-            this.process.off('exit', this.onExit.bind(this));
-
-            // Kill the live-captions process
-            this.process.kill();
-
-            // Set running to false
-            this.running = false;
-
-            // Resolve the promise
+            this.killExisting();
             resolve(true);
         });
     }
 
-    // Run the live-captions process from a path
-    private startLiveCaptions(exePath: string): Promise<boolean> {
-        return new Promise<boolean>((resolve) => {
-            if (this.running || (this.process && !this.process.killed)) {
-                resolve(true);
-                return;
+    // Launch the exe and confirm it's actually serving before reporting running.
+    // Retries once (with a fresh port sweep) if the server doesn't come up, so
+    // the Restart button can recover from a wedged/orphaned prior instance.
+    private async startLiveCaptions(exePath: string): Promise<boolean> {
+        for (let attempt = 1; attempt <= 2; attempt += 1) {
+            // Always start from a clean slate: no tracked process, port free.
+            this.killExisting();
+
+            // Start the live-captions process directly (NO shell wrapper).
+            // shell:true meant `this.process` was a cmd.exe wrapper, so kill()
+            // took down the wrapper and orphaned the real exe on port 3000.
+            const child = spawn(exePath, ['--skip-update-check']);
+            this.process = child;
+            child.stdout.on('data', (d) => this.logs.out.info(d.toString()));
+            child.stderr.on('data', (d) => this.logs.err.error(d.toString()));
+            // Identity-guarded: an OLD child exiting must not clobber the state
+            // of a NEWer one started on retry.
+            child.on(
+                'exit',
+                (code: number | null, signal: string | null) => {
+                    this.logs.out.log(
+                        `Live-captions exited (code ${code ?? 'null'}, signal ${
+                            signal ?? 'none'
+                        })`
+                    );
+                    if (this.process === child) {
+                        this.running = false;
+                        this.process = null;
+                    }
+                }
+            );
+            child.on('error', (err) => {
+                this.logs.err.error(
+                    `Live-captions failed to start: ${err.message}`
+                );
+                if (this.process === child) {
+                    this.running = false;
+                    this.process = null;
+                }
+            });
+
+            // Only report running once the server actually answers on :3000.
+            // eslint-disable-next-line no-await-in-loop
+            const up = await this.waitForServer();
+            if (up && this.process === child && !child.killed) {
+                this.running = true;
+                this.logs.out.log(
+                    `Live-captions is serving on port ${LiveCaptions.PORT}`
+                );
+                return true;
             }
 
-            // Start the live-captions process
-            this.process = spawn(exePath, ['--skip-update-check'], {
-                shell: true,
-            });
+            this.logs.err.error(
+                `Live-captions did not come up on attempt ${attempt}${ 
+                    attempt < 2 ? ' - retrying after a clean port sweep' : ''}`
+            );
+        }
 
-            // Log the stdout and stderr to files
-            this.process.stdout.on('data', (data) => {
-                this.logs.out.info(data.toString());
-            });
-            this.process.stderr.on('data', (data) => {
-                this.logs.err.error(data.toString());
-            });
-
-            this.process.on('exit', this.onExit.bind(this));
-        });
+        // Both attempts failed; leave it stopped and honest so the tab shows a
+        // Start button and the log carries the reason.
+        this.killExisting();
+        return false;
     }
 
-    private onExit(err: any) {
-        this.logs.out.log('Live-captions exited with code', err.code);
-        this.running = false;
+    // Whether the live-captions process is currently running
+    public isRunning(): boolean {
+        return this.running;
+    }
+
+    // Version string of the launched live-captions build
+    public getVersion(): string {
+        return this.currentVersion;
+    }
+
+    // Check GitHub for a newer live-captions without downloading it.
+    public async checkForUpdate(): Promise<{
+        current: string;
+        latest: string;
+        updateAvailable: boolean;
+    }> {
+        const found = glob.sync(path.join(appdataPath, 'live-captions-*.exe'));
+        let current = '0.0.0';
+        found.forEach((file) => {
+            const v = file.split('-').pop()?.split('.exe')[0] ?? '0.0.0';
+            if (v > current) current = v;
+        });
+        let latest = current;
+        try {
+            const baseUrl = getStore().get('liveCaptionsDownloadBase');
+            const res = await fetch(`${baseUrl}/latest`, {
+                signal: AbortSignal.timeout(8000),
+            });
+            latest = res.url.split('/').pop()?.slice(1) || current;
+        } catch (e) {
+            this.logs.err.warn('Update check failed', e);
+        }
+        return { current, latest, updateAvailable: latest > current };
     }
 
     public static get Instance(): LiveCaptions {

--- a/src/main/cutMatch.ts
+++ b/src/main/cutMatch.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import log from 'electron-log';
+
+// vMix ships an ffmpeg it already uses for streaming; reuse it so we don't have
+// to bundle our own. Fall back to an ffmpeg on PATH for the dev box.
+const VMIX_FFMPEG = 'C:\\Program Files (x86)\\vMix\\streaming\\ffmpeg6.exe';
+
+export function ffmpegPath(): string {
+    try {
+        if (fs.existsSync(VMIX_FFMPEG)) return VMIX_FFMPEG;
+    } catch {
+        // ignore
+    }
+    return 'ffmpeg';
+}
+
+function run(
+    bin: string,
+    args: string[]
+): Promise<{ code: number | null; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(bin, args, { windowsHide: true });
+        let stderr = '';
+        child.stderr.on('data', (d) => {
+            stderr += d.toString();
+        });
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code, stderr }));
+    });
+}
+
+// Read a file's duration (seconds) by parsing ffmpeg's own banner, so we don't
+// depend on ffprobe being present next to ffmpeg6.exe.
+async function probeDuration(file: string): Promise<number | null> {
+    const { stderr } = await run(ffmpegPath(), ['-i', file]);
+    const m = /Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/.exec(stderr);
+    if (!m) return null;
+    return (
+        parseInt(m[1], 10) * 3600 +
+        parseInt(m[2], 10) * 60 +
+        parseFloat(m[3])
+    );
+}
+
+export interface CutOptions {
+    matchKeep?: number; // seconds from start to keep (default 166)
+    resultsKeep?: number; // seconds from the end to keep (default 16)
+}
+
+// Cut the dead time out of a raw match recording: keep [0 -> matchKeep] (the
+// match + a few seconds after the buzzer) and [last resultsKeep] (the winner
+// animation + results screen), stitched with a frame-accurate re-encode. This
+// mirrors the standalone cut-matches script (libx264 CRF20 + AAC 192k). Short
+// recordings that never had dead time are just re-encoded whole.
+export default async function cutMatchVideo(
+    source: string,
+    outPath: string,
+    opts: CutOptions = {}
+): Promise<void> {
+    const matchKeep = opts.matchKeep ?? 166;
+    const resultsKeep = opts.resultsKeep ?? 16;
+
+    if (!fs.existsSync(source)) {
+        throw new Error(`Source not found: ${source}`);
+    }
+
+    const dur = await probeDuration(source);
+    if (dur == null) {
+        throw new Error('Could not read the recording duration');
+    }
+
+    const enc = [
+        '-c:v',
+        'libx264',
+        '-crf',
+        '20',
+        '-preset',
+        'medium',
+        '-pix_fmt',
+        'yuv420p',
+        '-c:a',
+        'aac',
+        '-b:a',
+        '192k',
+    ];
+
+    let args: string[];
+    if (dur <= matchKeep + resultsKeep) {
+        // No dead time to cut; re-encode the whole thing.
+        args = ['-y', '-v', 'error', '-i', source, ...enc, outPath];
+    } else {
+        const startB = (dur - resultsKeep).toFixed(3);
+        const fc =
+            `[0:v]trim=0:${matchKeep},setpts=PTS-STARTPTS[v0];` +
+            `[0:a]atrim=0:${matchKeep},asetpts=PTS-STARTPTS[a0];` +
+            `[0:v]trim=${startB},setpts=PTS-STARTPTS[v1];` +
+            `[0:a]atrim=${startB},asetpts=PTS-STARTPTS[a1];` +
+            `[v0][a0][v1][a1]concat=n=2:v=1:a=1[v][a]`;
+        args = [
+            '-y',
+            '-v',
+            'error',
+            '-i',
+            source,
+            '-filter_complex',
+            fc,
+            '-map',
+            '[v]',
+            '-map',
+            '[a]',
+            ...enc,
+            outPath,
+        ];
+    }
+
+    const { code, stderr } = await run(ffmpegPath(), args);
+    if (code !== 0) {
+        log.error('cutMatchVideo ffmpeg failed', stderr);
+        throw new Error(
+            `ffmpeg exited ${code}: ${stderr.split('\n').slice(-3).join(' ').trim()}`
+        );
+    }
+    if (!fs.existsSync(outPath)) {
+        throw new Error('ffmpeg reported success but produced no output file');
+    }
+}
+
+// Serialize cuts so a burst of matches doesn't spin up several parallel
+// re-encodes and starve vMix/streaming of CPU. Each task runs after the last.
+let queue: Promise<void> = Promise.resolve();
+
+export function enqueueCut(task: () => Promise<void>): Promise<void> {
+    queue = queue.then(task, task);
+    return queue;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { app, BrowserWindow, shell, globalShortcut } from 'electron';
+import { app, BrowserWindow, shell, globalShortcut, session } from 'electron';
 import log from 'electron-log';
 import MenuBuilder from './window_components/menu'; // eslint-disable-line import/no-cycle
 import {
@@ -84,6 +84,32 @@ const createWindow = async () => {
 
     mainWindow.loadURL(resolveHtmlPath('index.html'));
 
+    // The Live Captions settings page (served by live-captions on :3000) sends
+    // X-Frame-Options / a framing CSP that blocks it from loading in the tab's
+    // iframe (white screen). Strip those headers for that origin only so it can
+    // be embedded.
+    session.defaultSession.webRequest.onHeadersReceived(
+        {
+            urls: [
+                'http://localhost:3000/*',
+                'http://127.0.0.1:3000/*',
+            ],
+        },
+        (details, callback) => {
+            const headers = details.responseHeaders ?? {};
+            Object.keys(headers).forEach((key) => {
+                const lower = key.toLowerCase();
+                if (
+                    lower === 'x-frame-options' ||
+                    lower === 'content-security-policy'
+                ) {
+                    delete headers[key];
+                }
+            });
+            callback({ responseHeaders: headers });
+        }
+    );
+
     mainWindow.on('ready-to-show', () => {
         if (!mainWindow) {
             throw new Error('"mainWindow" is not defined');
@@ -134,6 +160,19 @@ export const quitApp = () => {
  */
 app.on('window-all-closed', () => {
     // app.quit();
+});
+
+// Kill addon child processes (esp. live-captions on port 3000) on EVERY quit
+// path - including electron-updater's relaunch and a menu/OS quit - not just our
+// own quitApp(). Otherwise an orphaned live-captions survives the update and
+// holds the port, which is what caused the recurring blank captions screen.
+app.on('before-quit', () => {
+    appIsQuitting = true;
+    try {
+        addons.stop();
+    } catch (e) {
+        log.error('Failed to stop addons on quit', e);
+    }
 });
 
 const instanceLock = app.requestSingleInstanceLock();

--- a/src/main/recordings/matchStore.ts
+++ b/src/main/recordings/matchStore.ts
@@ -1,0 +1,71 @@
+import Store from 'electron-store';
+import log from 'electron-log';
+import { MatchRecord } from '../../models/MatchRecord';
+
+// Keep the recorded-match history in its own store file (recordings.json in
+// userData), separate from the schema-validated app config store. History can
+// grow to a few hundred entries over an event, so it doesn't belong in config.
+const MAX_RECORDS = 300;
+
+type RecordingsSchema = {
+    matches: MatchRecord[];
+};
+
+let store: Store<RecordingsSchema> | undefined;
+
+function getRecordingsStore(): Store<RecordingsSchema> {
+    if (store === undefined) {
+        store = new Store<RecordingsSchema>({
+            name: 'recordings',
+            defaults: { matches: [] },
+        });
+    }
+    return store;
+}
+
+// Return all recorded matches, newest first.
+export function listMatches(): MatchRecord[] {
+    const matches = getRecordingsStore().get('matches', []);
+    return [...matches].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+// Insert a new record or replace an existing one with the same id.
+export function upsertMatch(record: MatchRecord): void {
+    const s = getRecordingsStore();
+    const matches = s.get('matches', []);
+    const idx = matches.findIndex((m) => m.id === record.id);
+    if (idx >= 0) {
+        matches[idx] = record;
+    } else {
+        matches.push(record);
+    }
+    // Prune oldest beyond the cap
+    const pruned = matches
+        .sort((a, b) => a.startedAt - b.startedAt)
+        .slice(-MAX_RECORDS);
+    s.set('matches', pruned);
+}
+
+// Merge a partial patch into an existing record. Returns the updated record,
+// or null if no record with that id exists.
+export function updateMatch(
+    id: string,
+    patch: Partial<MatchRecord>
+): MatchRecord | null {
+    const s = getRecordingsStore();
+    const matches = s.get('matches', []);
+    const idx = matches.findIndex((m) => m.id === id);
+    if (idx < 0) {
+        log.warn(`updateMatch: no record with id ${id}`);
+        return null;
+    }
+    const updated = { ...matches[idx], ...patch };
+    matches[idx] = updated;
+    s.set('matches', matches);
+    return updated;
+}
+
+// Wipe all recorded matches (manual/dev reset).
+export function clearMatches(): void {
+    getRecordingsStore().set('matches', []);
+}

--- a/src/main/recordings/matchStore.ts
+++ b/src/main/recordings/matchStore.ts
@@ -1,71 +1,81 @@
-import Store from 'electron-store';
+import fs from 'fs';
+import path from 'path';
 import log from 'electron-log';
 import { MatchRecord } from '../../models/MatchRecord';
 
-// Keep the recorded-match history in its own store file (recordings.json in
-// userData), separate from the schema-validated app config store. History can
-// grow to a few hundred entries over an event, so it doesn't belong in config.
-const MAX_RECORDS = 300;
+// Per-event match state lives in a JSON manifest that sits IN the recording
+// folder alongside the videos, not in a global app store. That way the Auto AV
+// tab's history simply reflects whatever folder the app is currently pointed at:
+// a new event means a new folder, which means a fresh (empty) history, with no
+// manual clearing needed. The manifest holds each match's metadata (teams,
+// cards) and its cut state.
+const MANIFEST = 'fimav-matches.json';
 
-type RecordingsSchema = {
-    matches: MatchRecord[];
-};
-
-let store: Store<RecordingsSchema> | undefined;
-
-function getRecordingsStore(): Store<RecordingsSchema> {
-    if (store === undefined) {
-        store = new Store<RecordingsSchema>({
-            name: 'recordings',
-            defaults: { matches: [] },
-        });
-    }
-    return store;
+function manifestPath(folder: string): string {
+    return path.join(folder, MANIFEST);
 }
 
-// Return all recorded matches, newest first.
-export function listMatches(): MatchRecord[] {
-    const matches = getRecordingsStore().get('matches', []);
-    return [...matches].sort((a, b) => b.startedAt - a.startedAt);
+function readManifest(folder: string): MatchRecord[] {
+    try {
+        const p = manifestPath(folder);
+        if (!fs.existsSync(p)) return [];
+        const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+        return Array.isArray(data?.matches) ? data.matches : [];
+    } catch (e) {
+        log.warn('readManifest failed', e);
+        return [];
+    }
+}
+
+function writeManifest(folder: string, matches: MatchRecord[]): void {
+    try {
+        if (!fs.existsSync(folder)) fs.mkdirSync(folder, { recursive: true });
+        fs.writeFileSync(
+            manifestPath(folder),
+            JSON.stringify({ version: 1, matches }, null, 2)
+        );
+    } catch (e) {
+        log.warn('writeManifest failed', e);
+    }
+}
+
+// All recorded matches in a folder, newest first. Empty when the folder is
+// unknown or has no manifest yet.
+export function listMatches(folder: string | null): MatchRecord[] {
+    if (!folder) return [];
+    return [...readManifest(folder)].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+// One record by id, or null.
+export function getMatch(folder: string | null, id: string): MatchRecord | null {
+    if (!folder) return null;
+    return readManifest(folder).find((m) => m.id === id) ?? null;
 }
 
 // Insert a new record or replace an existing one with the same id.
-export function upsertMatch(record: MatchRecord): void {
-    const s = getRecordingsStore();
-    const matches = s.get('matches', []);
+export function upsertMatch(folder: string, record: MatchRecord): void {
+    const matches = readManifest(folder);
     const idx = matches.findIndex((m) => m.id === record.id);
-    if (idx >= 0) {
-        matches[idx] = record;
-    } else {
-        matches.push(record);
-    }
-    // Prune oldest beyond the cap
-    const pruned = matches
-        .sort((a, b) => a.startedAt - b.startedAt)
-        .slice(-MAX_RECORDS);
-    s.set('matches', pruned);
+    if (idx >= 0) matches[idx] = record;
+    else matches.push(record);
+    writeManifest(folder, matches);
 }
 
-// Merge a partial patch into an existing record. Returns the updated record,
-// or null if no record with that id exists.
+// Merge a partial patch into an existing record. Returns the updated record, or
+// null if no record with that id exists in this folder.
 export function updateMatch(
+    folder: string,
     id: string,
     patch: Partial<MatchRecord>
 ): MatchRecord | null {
-    const s = getRecordingsStore();
-    const matches = s.get('matches', []);
+    const matches = readManifest(folder);
     const idx = matches.findIndex((m) => m.id === id);
     if (idx < 0) {
-        log.warn(`updateMatch: no record with id ${id}`);
+        log.warn(`updateMatch: no record ${id} in ${folder}`);
         return null;
     }
     const updated = { ...matches[idx], ...patch };
     matches[idx] = updated;
-    s.set('matches', matches);
+    writeManifest(folder, matches);
     return updated;
-}
-
-// Wipe all recorded matches (manual/dev reset).
-export function clearMatches(): void {
-    getRecordingsStore().set('matches', []);
 }

--- a/src/main/register-events.ts
+++ b/src/main/register-events.ts
@@ -16,6 +16,9 @@ import HWPing from './addons/hw-ping';
 import { getStore } from './store';
 import Event from '../models/Event';
 import AutoAV from './addons/autoav';
+import { AutoAVStatus } from '../models/AutoAVStatus';
+import { MatchRecord } from '../models/MatchRecord';
+import { listMatches, clearMatches } from './recordings/matchStore';
 import { StaticIpInfo } from '../models/HWCheckResponse';
 import { getCurrentEvent } from './util';
 
@@ -216,6 +219,29 @@ export default function registerAllEvents(window: BrowserWindow | null) {
             val: info,
         });
         lastAutoAV = info;
+    });
+
+    // Forward structured AutoAV status + match records to the Auto AV tab
+    let lastAutoAvStatus: AutoAVStatus = AutoAV.Instance.getStatus();
+    AutoAV.Instance.on('status', (status: AutoAVStatus) => {
+        lastAutoAvStatus = status;
+        window?.webContents.send('autoav:status', status);
+    });
+
+    AutoAV.Instance.on('match', (record: MatchRecord) => {
+        window?.webContents.send('autoav:match', record);
+    });
+
+    // The Auto AV tab requests the full current state on mount
+    ipcMain.on('autoav:getState', (event) => {
+        event.reply('autoav:status', lastAutoAvStatus);
+        event.reply('autoav:matches', listMatches());
+    });
+
+    // Manual/dev reset of the recorded-match history
+    ipcMain.on('autoav:clearMatches', (event) => {
+        clearMatches();
+        event.reply('autoav:matches', listMatches());
     });
 
     // Register a listener for the backend status.  Any time the renderer sends this event, we'll send the current status of the backend

--- a/src/main/register-events.ts
+++ b/src/main/register-events.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
+import fs from 'fs';
 import log from 'electron-log';
 import HWPingResponse, { IpConfigState } from 'models/HWPingResponse';
 import { EquipmentLogCategory, EquipmentLogType } from '../models/EquipmentLog';
@@ -16,9 +17,11 @@ import HWPing from './addons/hw-ping';
 import { getStore } from './store';
 import Event from '../models/Event';
 import AutoAV from './addons/autoav';
+import LiveCaptions from './addons/live-captions';
+import getVmixBandwidth, { streamKeyFromUrl } from './vmixBandwidth';
 import { AutoAVStatus } from '../models/AutoAVStatus';
 import { MatchRecord } from '../models/MatchRecord';
-import { listMatches, clearMatches } from './recordings/matchStore';
+import { listMatches } from './recordings/matchStore';
 import { StaticIpInfo } from '../models/HWCheckResponse';
 import { getCurrentEvent } from './util';
 
@@ -176,11 +179,107 @@ export default function registerAllEvents(window: BrowserWindow | null) {
             });
     });
 
-    // Listen for stream start/stop events
+    // Push the YouTube caption ingestion URL into live-captions. YouTube's HTTP
+    // caption ingestion uses cid=<stream key>, so we can build it straight from
+    // the RTMP stream key and configure live-captions over its tRPC API
+    // (httpBatchLink, no transformer → body is {"0": <input>}).
+    async function pushYouTubeCaptions(streams: any[]) {
+        const yt = streams.find((s) =>
+            /youtube/i.test(s?.rtmpUrl ?? '')
+        );
+        const key = yt?.rtmpKey || streamKeyFromUrl(yt?.rtmpUrl ?? '');
+        if (!key) return;
+        const url = `http://upload.youtube.com/closedcaption?cid=${key}`;
+        const post = (proc: string, input: unknown) =>
+            fetch(`http://127.0.0.1:3000/trpc/${proc}?batch=1`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ '0': input }),
+                signal: AbortSignal.timeout(5000),
+            });
+        try {
+            await post('youtubeCaptions.setUrl', { url });
+            await post('youtubeCaptions.setEnabled', { enabled: true });
+            invokeLog('Pushed YouTube caption URL to live-captions');
+        } catch (e) {
+            log.error('Failed to push YouTube caption URL', e);
+        }
+    }
+
+    // #region vMix stream-key validation state
+    // When true, the next inbound StreamInfo is a read-only validation poll and
+    // must NOT be pushed to vMix (so a comparison poll never re-writes live keys
+    // mid-stream). Set right before a poll's invoke('GetStreamInfo').
+    let suppressStreamPush = false;
+    let suppressResetTimer: ReturnType<typeof setTimeout> | null = null;
+    // Latest key comparison, surfaced in the vMix tab.
+    let keyValidation: {
+        checked: boolean;
+        match: boolean | null;
+        cloudKeys: string[];
+        runningKeys: string[];
+    } = { checked: false, match: null, cloudKeys: [], runningKeys: [] };
+
+    // Compare the admin hub's current keys to what ffmpeg is actually streaming.
+    async function computeKeyValidation(cloudKeys: string[]) {
+        const bw = await getVmixBandwidth();
+        const runningKeys = Array.from(
+            new Set(
+                bw.streams
+                    .map((s) => streamKeyFromUrl(s.rtmpUrl))
+                    .filter(Boolean)
+            )
+        );
+        const cloud = Array.from(new Set(cloudKeys.filter(Boolean)));
+        // Only a real verdict when we have both sides. Match = every running key
+        // is present in the cloud set (vMix streaming with a current key).
+        let match: boolean | null = null;
+        if (cloud.length > 0 && runningKeys.length > 0) {
+            match = runningKeys.every((k) => cloud.includes(k));
+        }
+        keyValidation = { checked: true, match, cloudKeys: cloud, runningKeys };
+        const s = await buildVmixStatus();
+        window?.webContents.send('vmix:status', s);
+    }
+
+    // Listen for stream info from the admin hub. Two paths: a normal push (the
+    // Set Stream Keys action) writes the keys into vMix; a validation poll
+    // (suppressStreamPush) only compares them, never writing.
     registerListener('StreamInfo', (info) => {
+        const streams = (info as any[]) ?? [];
+        if (suppressStreamPush) {
+            suppressStreamPush = false;
+            if (suppressResetTimer) {
+                clearTimeout(suppressResetTimer);
+                suppressResetTimer = null;
+            }
+            const cloudKeys = streams
+                .map((s: any) => s.rtmpKey ?? streamKeyFromUrl(s.rtmpUrl ?? ''))
+                .filter(Boolean);
+            computeKeyValidation(cloudKeys).catch((e) =>
+                log.error('Key validation failed', e)
+            );
+            return;
+        }
+
         VmixService.Instance.SetStreamInfo(info as any)
             .then(() => {
                 invokeLog(`Stream info updated`);
+                // Record that we set stream keys for the current event, so the
+                // vMix tab can show "keys set for <event>" (vMix can't be read
+                // back for this).
+                const ev = AutoAV.Instance.getStatus().currentEvent;
+                store.set('vmixStreamKeys', {
+                    eventCode: ev?.code ?? '',
+                    eventName: ev?.name ?? 'Unknown Event',
+                    setAt: Date.now(),
+                });
+                // Also configure live-captions' YouTube caption push from the
+                // same key (cid == stream key).
+                pushYouTubeCaptions((info as any[]) ?? []);
+                buildVmixStatus()
+                    .then((s) => window?.webContents.send('vmix:status', s))
+                    .catch(() => {});
                 return null;
             })
             .catch((err) => {
@@ -192,11 +291,212 @@ export default function registerAllEvents(window: BrowserWindow | null) {
                 });
             });
     });
+    // #endregion vMix stream-key validation state
 
     registerListener('GetVmixConfig', async () => {
         const resp = await VmixService.Instance.GetBase();
         return JSON.stringify(resp);
     });
+
+    // #region vMix tab
+
+    // Build the vMix tab status: live reachability/recording/streaming from a
+    // single GetBase call, plus whether stream keys were set for THIS event.
+    async function buildVmixStatus() {
+        let reachable = false;
+        let recording = false;
+        let streaming = false;
+        try {
+            const parsed = await VmixService.Instance.GetBase();
+            reachable = !!parsed?.vmix;
+            recording = parsed?.vmix?.recording?.['#text'] === 'True';
+            const s = parsed?.vmix?.streaming;
+            const sText = typeof s === 'object' ? s?.['#text'] : s;
+            streaming = sText === 'True' || sText === true;
+        } catch {
+            reachable = false;
+        }
+
+        const {currentEvent} = AutoAV.Instance.getStatus();
+        const keys = store.get('vmixStreamKeys');
+        // Only count keys as "set for this event" if the recorded event matches
+        // the one running now (by code when available, else name).
+        const keysSetForEvent =
+            !!keys &&
+            !!currentEvent &&
+            (currentEvent.code
+                ? keys.eventCode === currentEvent.code
+                : keys.eventName === currentEvent.name);
+
+        return {
+            reachable,
+            recording,
+            streaming,
+            currentEvent,
+            streamKeys: keys,
+            keysSetForEvent,
+            keyValidation,
+        };
+    }
+
+    ipcMain.on('vmix:getStatus', async (event) => {
+        event.reply('vmix:status', await buildVmixStatus());
+    });
+
+    // Read-only key validation poll: ask the admin hub for the current keys
+    // (handled in the suppressed StreamInfo branch, which compares without
+    // pushing to vMix). Safety timer clears the suppress flag if no response.
+    ipcMain.on('vmix:pollKeys', () => {
+        suppressStreamPush = true;
+        if (suppressResetTimer) clearTimeout(suppressResetTimer);
+        suppressResetTimer = setTimeout(() => {
+            suppressStreamPush = false;
+            suppressResetTimer = null;
+        }, 10000);
+        invoke('GetStreamInfo');
+    });
+
+    // Live streaming bandwidth (per-stream ffmpeg bitrate). Polled only while the
+    // vMix tab is open, so the PowerShell call costs nothing off-tab.
+    ipcMain.on('vmix:getBandwidth', async (event) => {
+        event.reply('vmix:bandwidth', await getVmixBandwidth());
+    });
+
+    ipcMain.on('vmix:getSettings', (event) => {
+        event.reply('vmix:settings', store.get('vmixApi'));
+    });
+
+    ipcMain.on('vmix:saveSettings', (event, [vmixApi]) => {
+        store.set('vmixApi', vmixApi);
+        VmixService.Instance.updateSettings(vmixApi);
+        event.reply('vmix:settings', store.get('vmixApi'));
+    });
+
+    ipcMain.on('vmix:testConnection', async (event, [vmixApi]) => {
+        try {
+            const parsed = await new VmixService(vmixApi).GetBase();
+            const ok = !!parsed?.vmix;
+            event.reply('vmix:testResult', {
+                ok,
+                message: ok
+                    ? 'Connected to vMix'
+                    : 'Reached the address but it did not answer as vMix',
+            });
+        } catch (e) {
+            event.reply('vmix:testResult', {
+                ok: false,
+                message: `Could not reach vMix: ${(e as Error).message}`,
+            });
+        }
+    });
+
+    // Set stream keys: mirrors the old menu action - ask the server for this
+    // event's stream info over SignalR, which comes back through the StreamInfo
+    // listener above and gets pushed into vMix (and recorded).
+    ipcMain.on('vmix:setStreamKeys', (event) => {
+        const timeout = setTimeout(() => {
+            event.reply('vmix:action', {
+                ok: false,
+                action: 'setStreamKeys',
+                message: 'Timed out asking the server for stream keys',
+            });
+        }, 10000);
+        VmixService.Instance.events.once(
+            'streamInfoUpdated',
+            async (success: boolean) => {
+                clearTimeout(timeout);
+                event.reply('vmix:action', {
+                    ok: success,
+                    action: 'setStreamKeys',
+                    message: success
+                        ? 'Stream keys set in vMix'
+                        : 'Failed to set stream keys - check the logs',
+                });
+                event.reply('vmix:status', await buildVmixStatus());
+            }
+        );
+        invoke('GetStreamInfo');
+    });
+
+    ipcMain.on('vmix:addLiveCaptionsInput', async (event) => {
+        try {
+            await VmixService.Instance.AddLiveCaptionsInput();
+            event.reply('vmix:action', {
+                ok: true,
+                action: 'addLiveCaptionsInput',
+                message: 'Added Live Captions input to vMix',
+            });
+        } catch (e) {
+            event.reply('vmix:action', {
+                ok: false,
+                action: 'addLiveCaptionsInput',
+                message: `Failed: ${(e as Error).message}`,
+            });
+        }
+    });
+
+    ipcMain.on('vmix:addAudienceDisplayInput', async (event) => {
+        try {
+            await VmixService.Instance.AddAudienceDisplayInput();
+            event.reply('vmix:action', {
+                ok: true,
+                action: 'addAudienceDisplayInput',
+                message: 'Added Audience Display input to vMix',
+            });
+        } catch (e) {
+            event.reply('vmix:action', {
+                ok: false,
+                action: 'addAudienceDisplayInput',
+                message: `Failed: ${(e as Error).message}`,
+            });
+        }
+    });
+
+    // Alliance-selection composite: list inputs for the pickers, read/apply the
+    // (tunable, saved) geometry that overlays the camera on the base input.
+    ipcMain.on('vmix:getInputs', async (event) => {
+        try {
+            event.reply('vmix:inputs', await VmixService.Instance.GetInputs());
+        } catch {
+            event.reply('vmix:inputs', []);
+        }
+    });
+
+    ipcMain.on('vmix:getComposite', (event) => {
+        event.reply('vmix:composite', store.get('vmixComposite'));
+    });
+
+    ipcMain.on('vmix:applyComposite', async (event, [cfg]) => {
+        try {
+            await VmixService.Instance.CreateAllianceComposite(
+                cfg.fmsKey,
+                cfg.cameraKey,
+                cfg.zoom,
+                cfg.panX,
+                cfg.panY
+            );
+            // Persist the geometry (not the input keys, which vary per session).
+            store.set('vmixComposite', {
+                layer: cfg.layer,
+                zoom: cfg.zoom,
+                panX: cfg.panX,
+                panY: cfg.panY,
+            });
+            event.reply('vmix:action', {
+                ok: true,
+                action: 'applyComposite',
+                message: 'Alliance Selection Composite input ready',
+            });
+        } catch (e) {
+            event.reply('vmix:action', {
+                ok: false,
+                action: 'applyComposite',
+                message: `Failed: ${(e as Error).message}`,
+            });
+        }
+    });
+
+    // #endregion vMix tab
 
     // Register a emitter listener for the hwping response.  Any time the hwping service updates, we'll send the updated list to the renderer
     HWPing.Instance.on('hw-change', (res: HWPingResponse) => {
@@ -232,16 +532,150 @@ export default function registerAllEvents(window: BrowserWindow | null) {
         window?.webContents.send('autoav:match', record);
     });
 
+    // The recorded-match list for the folder the app is currently pointed at,
+    // pushed whenever the event folder changes.
+    AutoAV.Instance.on('matches', (matches: MatchRecord[]) => {
+        window?.webContents.send('autoav:matches', matches);
+    });
+
     // The Auto AV tab requests the full current state on mount
     ipcMain.on('autoav:getState', (event) => {
         event.reply('autoav:status', lastAutoAvStatus);
-        event.reply('autoav:matches', listMatches());
+        event.reply(
+            'autoav:matches',
+            listMatches(lastAutoAvStatus.saveFolder)
+        );
     });
 
-    // Manual/dev reset of the recorded-match history
-    ipcMain.on('autoav:clearMatches', (event) => {
-        clearMatches();
-        event.reply('autoav:matches', listMatches());
+    // Manually cut the dead time out of a recorded match (the Cut button).
+    ipcMain.on('autoav:cutMatch', (_event, [folder, id]) => {
+        if (typeof folder === 'string' && typeof id === 'string') {
+            AutoAV.Instance.queueCut(folder, id);
+        }
+    });
+
+    // AutoAV addon controls (top control row on the Auto AV tab)
+    ipcMain.on('autoav:restart', (event) => {
+        AutoAV.Instance.stop();
+        AutoAV.Instance.start();
+        event.reply('autoav:status', AutoAV.Instance.getStatus());
+    });
+
+    ipcMain.on('autoav:stopAddon', (event) => {
+        AutoAV.Instance.stop();
+        event.reply('autoav:status', AutoAV.Instance.getStatus());
+    });
+
+    // Live Captions status + controls for the Live Captions tab
+    const liveCaptionsStatus = () => ({
+        running: LiveCaptions.Instance.isRunning(),
+        version: LiveCaptions.Instance.getVersion(),
+    });
+
+    ipcMain.on('liveCaptions:getStatus', (event) => {
+        event.reply('liveCaptions:status', liveCaptionsStatus());
+    });
+
+    ipcMain.on('liveCaptions:restart', async (event) => {
+        try {
+            await LiveCaptions.Instance.stop();
+            await LiveCaptions.Instance.start();
+        } catch (e) {
+            log.error('Live-captions restart failed', e);
+        }
+        event.reply('liveCaptions:status', liveCaptionsStatus());
+    });
+
+    ipcMain.on('liveCaptions:stop', async (event) => {
+        try {
+            await LiveCaptions.Instance.stop();
+        } catch (e) {
+            log.error('Live-captions stop failed', e);
+        }
+        event.reply('liveCaptions:status', liveCaptionsStatus());
+    });
+
+    // Version click → check GitHub for a newer live-captions build.
+    ipcMain.on('liveCaptions:checkUpdate', async (event) => {
+        event.reply(
+            'liveCaptions:updateInfo',
+            await LiveCaptions.Instance.checkForUpdate()
+        );
+    });
+
+    // Confirmed update: stop, re-start (start() downloads the newest), then
+    // reload the vMix Live Captions browser input so it serves the new build.
+    ipcMain.on('liveCaptions:update', async (event) => {
+        try {
+            await LiveCaptions.Instance.stop();
+            await LiveCaptions.Instance.start();
+            try {
+                await VmixService.Instance.ReloadBrowserInput('Live Captions');
+            } catch (e) {
+                log.warn('Could not reload vMix Live Captions input', e);
+            }
+        } catch (e) {
+            log.error('Live-captions update failed', e);
+        }
+        event.reply('liveCaptions:status', liveCaptionsStatus());
+    });
+
+    // Auto AV settings dialog: naming + save folder (vMix connection now lives
+    // in the vMix tab).
+    const autoAvSettings = () => ({
+        fileNameMode: store.get('autoAv.fileNameMode', 'in-season'),
+        eventNameOverride: store.get('autoAv.eventNameOverride', ''),
+        saveFolder: store.get('autoAv.saveFolder', ''),
+        autoCut: store.get('autoAv.autoCut', false),
+    });
+
+    ipcMain.on('autoav:getSettings', (event) => {
+        event.reply('autoav:settings', autoAvSettings());
+    });
+
+    // Open the current recording folder in Explorer (folder icon on the tab)
+    ipcMain.on('autoav:openFolder', () => {
+        const folder = AutoAV.Instance.getStatus().saveFolder;
+        if (folder) {
+            // Create it first if it doesn't exist yet, so the open succeeds even
+            // before the first recording lands.
+            try {
+                if (!fs.existsSync(folder)) {
+                    fs.mkdirSync(folder, { recursive: true });
+                }
+            } catch {
+                // best effort
+            }
+            shell.openPath(folder);
+        }
+    });
+
+    // Reveal a specific file (e.g. a cut output) in Explorer, selected.
+    ipcMain.on('autoav:revealFile', (_event, [filePath]) => {
+        if (typeof filePath === 'string' && filePath) {
+            shell.showItemInFolder(filePath);
+        }
+    });
+
+    // Native folder picker for the save-folder field
+    ipcMain.on('autoav:pickFolder', async (event) => {
+        const win = BrowserWindow.getFocusedWindow() ?? window ?? undefined;
+        const result = await (win
+            ? dialog.showOpenDialog(win, { properties: ['openDirectory'] })
+            : dialog.showOpenDialog({ properties: ['openDirectory'] }));
+        if (!result.canceled && result.filePaths[0]) {
+            event.reply('autoav:folderPicked', result.filePaths[0]);
+        }
+    });
+
+    // Persist Auto AV settings and apply them live.
+    ipcMain.on('autoav:saveSettings', (event, [settings]) => {
+        store.set('autoAv.fileNameMode', settings.fileNameMode);
+        store.set('autoAv.eventNameOverride', settings.eventNameOverride ?? '');
+        store.set('autoAv.saveFolder', settings.saveFolder ?? '');
+        store.set('autoAv.autoCut', !!settings.autoCut);
+        AutoAV.Instance.applySettings();
+        event.reply('autoav:settings', autoAvSettings());
     });
 
     // Register a listener for the backend status.  Any time the renderer sends this event, we'll send the current status of the backend

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -12,8 +12,33 @@ export type AppConfig = {
         username: string;
         password: string;
     };
+    // Last event we successfully pushed stream keys to vMix for. vMix can't be
+    // read back for the key, so we track "did we set it for this event" here.
+    vmixStreamKeys: {
+        eventCode: string;
+        eventName: string;
+        setAt: number;
+    } | null;
+    // Saved alliance-selection composite geometry (tunable live, then saved).
+    vmixComposite: {
+        layer: number;
+        zoom: number;
+        panX: number;
+        panY: number;
+    };
     autoAv: {
         fileNameMode: 'in-season' | 'off-season';
+        // Manual event name; when set it overrides whatever FMS reports
+        eventNameOverride: string;
+        // Destination folder for renamed match videos; blank = alongside the
+        // vMix recording
+        saveFolder: string;
+        // The actual event folder the last recording was filed into, so the tab
+        // can show the real path even with no configured save folder
+        lastSaveFolder: string;
+        // Auto-cut the dead time out of each recording after it's filed,
+        // producing a clean uploadable copy in a "Cut" subfolder.
+        autoCut: boolean;
     };
 };
 
@@ -49,7 +74,7 @@ export function createStore(): Store<AppConfig> {
                 properties: {
                     baseUrl: {
                         type: 'string',
-                        default: 'http://127.0.0.1:8000/api',
+                        default: 'http://127.0.0.1:8088/api',
                     },
                     username: {
                         type: 'string',
@@ -61,12 +86,44 @@ export function createStore(): Store<AppConfig> {
                     },
                 },
             },
+            vmixStreamKeys: {
+                type: ['object', 'null'],
+                default: null,
+            },
+            vmixComposite: {
+                type: 'object',
+                // Perfect-fit values for the official AD camera box, measured
+                // live (X133.6 Y29.2 W844.4 H475 in 1920x1080): zoom = W/1920,
+                // panX = (centerX-960)/960, panY = (540-centerY)/540.
+                default: {
+                    layer: 1,
+                    zoom: 0.4398,
+                    panX: -0.421,
+                    panY: 0.5061,
+                },
+            },
             autoAv: {
                 type: 'object',
                 properties: {
                     fileNameMode: {
                         type: 'string',
                         default: 'in-season',
+                    },
+                    eventNameOverride: {
+                        type: 'string',
+                        default: '',
+                    },
+                    saveFolder: {
+                        type: 'string',
+                        default: '',
+                    },
+                    lastSaveFolder: {
+                        type: 'string',
+                        default: '',
+                    },
+                    autoCut: {
+                        type: 'boolean',
+                        default: false,
                     },
                 },
             },
@@ -95,6 +152,20 @@ export function createStore(): Store<AppConfig> {
             },
             '0.0.29': (store) => {
                 store.set('autoAv.fileNameMode', 'in-season');
+            },
+            // vMix serves its web API on 8088 by default; the old 8000 default
+            // was a placeholder that never matched a stock vMix. Repoint any
+            // install still on it.
+            '2026.2.3': (store) => {
+                const vmix = store.get('vmixApi') as
+                    | AppConfig['vmixApi']
+                    | undefined;
+                if (vmix?.baseUrl === 'http://127.0.0.1:8000/api') {
+                    store.set('vmixApi', {
+                        ...vmix,
+                        baseUrl: 'http://127.0.0.1:8088/api',
+                    });
+                }
             },
         },
     }) as Store<AppConfig>;

--- a/src/main/vmixBandwidth.ts
+++ b/src/main/vmixBandwidth.ts
@@ -1,0 +1,177 @@
+import fs from 'fs';
+import path from 'path';
+import log from 'electron-log';
+
+export interface VmixStream {
+    // vMix stream index (from the log filename: "streaming<N> ...")
+    index: number;
+    // Target/max video bitrate in kbps parsed from the ffmpeg command line
+    targetKbps: number | null;
+    maxrateKbps: number | null;
+    // Live bitrate in kbps = the last bitrate= value in the ffmpeg log
+    liveKbps: number | null;
+    // Friendly destination label (e.g. "YouTube (primary)")
+    destination: string;
+    // Full rtmp URL ffmpeg is streaming to (includes the stream key)
+    rtmpUrl: string;
+}
+
+export interface VmixBandwidth {
+    streams: VmixStream[];
+    supported: boolean;
+    // True on the first poll after logs appear, when there is no prior size to
+    // compare against yet, so activity can't be judged this tick. The UI keeps
+    // the loading spinner up until this clears.
+    warming?: boolean;
+}
+
+export function streamKeyFromUrl(url: string): string {
+    const noQuery = url.split('?')[0];
+    return noQuery.split('/').filter(Boolean).pop() ?? '';
+}
+
+const LOG_DIR = 'C:\\ProgramData\\vMix\\streaming';
+
+// Per-log file size seen on the previous poll, keyed by full path. A stream is
+// "active" when its log grew since the last poll (~3s ago) - no in-call sleep
+// and no background loop needed, just compare against last time.
+const lastSize = new Map<string, number>();
+
+function labelDestination(commandLine: string): string {
+    const rtmp = /rtmp:\/\/([^/"\s]+)/i.exec(commandLine);
+    const host = rtmp?.[1] ?? '';
+    if (/backup=1/i.test(commandLine) || /^b\./i.test(host)) {
+        return 'YouTube (backup)';
+    }
+    if (/youtube/i.test(host) || /^a\./i.test(host)) {
+        return 'YouTube (primary)';
+    }
+    return host || 'Unknown';
+}
+
+function rtmpUrl(commandLine: string): string {
+    const m = /rtmp:\/\/[^\s"]+/i.exec(commandLine);
+    return m?.[0] ?? '';
+}
+
+function parseKbps(commandLine: string, flag: string): number | null {
+    const re = new RegExp(`${flag}\\s+(\\d+)k`, 'i');
+    const m = re.exec(commandLine);
+    return m ? parseInt(m[1], 10) : null;
+}
+
+// Newest log file per stream slot. vMix names them "streaming<N> <timestamp>.log"
+// so the lexically-highest name per slot is the most recent one.
+function newestLogs(): { index: number; file: string }[] {
+    let names: string[];
+    try {
+        names = fs.readdirSync(LOG_DIR);
+    } catch {
+        return [];
+    }
+    const bySlot = new Map<number, string>();
+    names.forEach((name) => {
+        const m = /^streaming(\d+).*\.log$/i.exec(name);
+        if (!m) return;
+        const idx = parseInt(m[1], 10);
+        const cur = bySlot.get(idx);
+        if (!cur || name > cur) bySlot.set(idx, name);
+    });
+    return [...bySlot.entries()].map(([index, name]) => ({
+        index,
+        file: path.join(LOG_DIR, name),
+    }));
+}
+
+// Read the current size + head (ffmpeg command line) + tail (progress lines)
+// off an OPEN handle. libuv opens with full share flags so this works while
+// ffmpeg holds the log open, and fstat returns the true current EOF (unlike
+// directory metadata, which NTFS leaves stale for open files).
+function readParts(
+    file: string
+): { size: number; head: string; tail: string } | null {
+    let fd: number | undefined;
+    try {
+        fd = fs.openSync(file, 'r');
+        const { size } = fs.fstatSync(fd);
+        const headLen = Math.min(8192, size);
+        const headBuf = Buffer.alloc(headLen);
+        if (headLen > 0) fs.readSync(fd, headBuf, 0, headLen, 0);
+        const tailLen = Math.min(65536, size);
+        const tailBuf = Buffer.alloc(tailLen);
+        if (tailLen > 0) fs.readSync(fd, tailBuf, 0, tailLen, size - tailLen);
+        return {
+            size,
+            head: headBuf.toString('utf8'),
+            tail: tailBuf.toString('utf8'),
+        };
+    } catch {
+        return null;
+    } finally {
+        if (fd !== undefined) fs.closeSync(fd);
+    }
+}
+
+// Read live vMix streaming bandwidth. Windows-only; returns supported:false
+// elsewhere (e.g. the dev box). Runs on demand (no spawn, no sleep): reads each
+// active log's tail and takes the last bitrate= value verbatim.
+export default function getVmixBandwidth(): Promise<VmixBandwidth> {
+    if (process.platform !== 'win32') {
+        return Promise.resolve({ streams: [], supported: false });
+    }
+    try {
+        const logs = newestLogs();
+        const seen = new Set<string>();
+        const streams: VmixStream[] = [];
+        let hadAnyBaseline = false;
+
+        logs.forEach(({ index, file }) => {
+            seen.add(file);
+            const parts = readParts(file);
+            if (!parts) return;
+
+            const prev = lastSize.get(file);
+            if (prev !== undefined) hadAnyBaseline = true;
+            lastSize.set(file, parts.size);
+            // Active = grew since the previous poll. First poll has no baseline,
+            // so a stream shows up one tick later - cheaper than sleeping.
+            if (prev === undefined || parts.size <= prev) return;
+
+            const cmd = (/^.*ffmpeg6\.exe.*$/im.exec(parts.head) || [''])[0];
+            // Bitrate = the last bitrate= value in the log, verbatim (m -> kbps).
+            const ms = [
+                ...parts.tail.matchAll(/bitrate=\s*([\d.]+)(k|m)bits\/s/gi),
+            ];
+            let kbps: number | null = null;
+            if (ms.length > 0) {
+                const last = ms[ms.length - 1];
+                kbps =
+                    parseFloat(last[1]) *
+                    (last[2].toLowerCase() === 'm' ? 1000 : 1);
+            }
+
+            streams.push({
+                index,
+                targetKbps: parseKbps(cmd, '-b:v'),
+                maxrateKbps: parseKbps(cmd, '-maxrate:v'),
+                liveKbps: kbps != null ? Math.max(0, kbps) : null,
+                destination: labelDestination(cmd),
+                rtmpUrl: rtmpUrl(cmd),
+            });
+        });
+
+        // Forget logs that vanished so a new session starts clean.
+        [...lastSize.keys()].forEach((k) => {
+            if (!seen.has(k)) lastSize.delete(k);
+        });
+
+        streams.sort((a, b) => a.index - b.index);
+        // Logs exist but we had no baseline for any of them: this is the first
+        // poll of a fresh session, so we can't tell what's active yet.
+        const warming = logs.length > 0 && !hadAnyBaseline;
+        return Promise.resolve({ streams, supported: true, warming });
+    } catch (e) {
+        log.warn('vMix bandwidth read failed', e);
+        return Promise.resolve({ streams: [], supported: true });
+    }
+}

--- a/src/main/window_components/menu.ts
+++ b/src/main/window_components/menu.ts
@@ -4,17 +4,13 @@ import {
     shell,
     BrowserWindow,
     MenuItemConstructorOptions,
-    dialog,
 } from 'electron';
 import Addons from 'main/addons';
 import { platform } from 'os';
 import { updateNow } from '../updates/update';
 import { isDebug, logsPath } from '../util';
-import createAlertsWindow, { getAlertsWindow } from './alertsWindow';
 import { quitApp } from '../main'; // eslint-disable-line import/no-cycle
-import VmixService from '../../services/VmixService';
 import AutoAV from '../addons/autoav';
-import { invoke } from './signalR';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
     selector?: string;
@@ -40,8 +36,8 @@ export default class MenuBuilder {
         return menu;
     }
 
+    // eslint-disable-next-line class-methods-use-this
     buildDefaultTemplate(dev: boolean) {
-        const that = this;
         const templateDefault: MenuItemConstructorOptions[] = [];
 
         if (platform() === 'darwin') {
@@ -70,120 +66,14 @@ export default class MenuBuilder {
 
         templateDefault.push(
             ...([
-                {
-                    label: 'Alerts',
-                    submenu: [
-                        {
-                            label: 'View Alerts',
-                            click() {
-                                const alertsWindow = getAlertsWindow();
-                                if (alertsWindow) {
-                                    alertsWindow.show();
-                                } else {
-                                    createAlertsWindow();
-                                }
-                            },
-                        },
-                    ],
-                },
-                {
-                    label: 'Addons',
-                    submenu: [
-                        {
-                            label: 'Live Captions',
-                            submenu: [
-                                {
-                                    label: 'Restart',
-                                    click() {
-                                        that.addons.restartLiveCaptions();
-                                    },
-                                },
-                                {
-                                    label: 'Settings',
-                                    click() {
-                                        MenuBuilder.openLiveCapSettings();
-                                    },
-                                },
-                                {
-                                    label: 'About',
-                                    click() {
-                                        MenuBuilder.openLiveCapSettings(
-                                            'about'
-                                        );
-                                    },
-                                },
-                            ],
-                        },
-                        {
-                            label: 'AutoAV',
-                            submenu: [
-                                {
-                                    label: 'Restart',
-                                    click() {
-                                        that.addons.restartAutoAV();
-                                    },
-                                },
-                            ],
-                        },
-                        {
-                            label: 'Restart All',
-                            click() {
-                                that.addons.restartAll();
-                            },
-                        },
-                    ],
-                },
-                {
-                    label: 'vMix',
-                    submenu: [
-                        {
-                            label: 'Set Stream Keys',
-                            click: async () => {
-                                // Set a timeout for the stream keys, if we don't get a response in 10 seconds, show a message box
-                                const timeout = setTimeout(() => {
-                                    dialog.showMessageBox({
-                                        message:
-                                            'Failed to set stream keys: Timed out',
-                                        title: 'vMix Streaming',
-                                        type: 'info',
-                                    });
-                                }, 10000);
-
-                                VmixService.Instance.events.once(
-                                    'streamInfoUpdated',
-                                    (success: boolean) => {
-                                        // Clear the timeout
-                                        clearTimeout(timeout);
-
-                                        // Show a message
-                                        dialog.showMessageBox({
-                                            message: success
-                                                ? 'Successfully set vMix streaming locations'
-                                                : 'Failed to set streaming locations. Check the log for more details.',
-                                            title: 'vMix Streaming',
-                                            type: 'info',
-                                        });
-                                    }
-                                );
-
-                                // This will trigger SignalR to send us the stream info, which is being listened for in register-events.ts
-                                invoke('GetStreamInfo');
-                            },
-                        },
-                        {
-                            label: 'Add Live Captions input',
-                            click() {
-                                MenuBuilder.addLiveCapInput();
-                            },
-                        },
-                        {
-                            label: 'Add Audience Display (Web) input',
-                            click() {
-                                MenuBuilder.addAudienceDisplayWebInput();
-                            },
-                        },
-                        ...(dev
-                            ? ([
+                // Alerts now live in the tab-bar notification bell.
+                // vMix controls now live in the vMix tab. Only the dev-only
+                // manual recording triggers remain, behind the dev flag.
+                ...(dev
+                    ? ([
+                          {
+                              label: 'vMix (Dev)',
+                              submenu: [
                                   {
                                       label: 'Start Recording (Dev)',
                                       click() {
@@ -196,10 +86,10 @@ export default class MenuBuilder {
                                           AutoAV.Instance.devStopRecording();
                                       },
                                   },
-                              ] as MenuItemConstructorOptions[])
-                            : []),
-                    ],
-                },
+                              ],
+                          },
+                      ] as MenuItemConstructorOptions[])
+                    : []),
                 {
                     label: 'About',
                     submenu: [
@@ -280,82 +170,4 @@ export default class MenuBuilder {
         window.show();
     }
 
-    static async addLiveCapInput() {
-        try {
-            // Add input to vMix
-            await VmixService.Instance.AddBrowserInput(
-                'http://127.0.0.1:3000/'
-            );
-
-            // Get inputs
-            const parsed = await VmixService.Instance.GetBase();
-
-            // Find the input we just added
-            let found = false;
-            parsed.vmix.inputs.input.forEach(async (input: any) => {
-                if (
-                    !found &&
-                    input.type === 'Browser' &&
-                    input.title === 'Browser 127.0.0.1'
-                ) {
-                    // Rename it
-                    await VmixService.Instance.RenameInput(
-                        input.key,
-                        'Live Captions'
-                    );
-                    found = true;
-                }
-            });
-        } catch (err) {
-            // Sadness
-            dialog.showErrorBox('Failed', 'Unable to communicate with vMix');
-        }
-    }
-
-    static async addAudienceDisplayWebInput() {
-        try {
-            // Add input to vMix
-            await VmixService.Instance.AddBrowserInput(
-                'http://10.0.100.5/AudienceDisplay'
-            );
-
-            // Get inputs
-            const parsed = await VmixService.Instance.GetBase();
-
-            // Find the input we just added
-            let found = false;
-            parsed.vmix.inputs.input.forEach(async (input: any) => {
-                if (
-                    !found &&
-                    input.type === 'Browser' &&
-                    input.title === 'Browser 10.0.100.5'
-                ) {
-                    // Rename it
-                    await VmixService.Instance.RenameInput(
-                        input.key,
-                        'Audience Display'
-                    );
-                    await VmixService.Instance.SetInputAudioAlwaysOn(input.key);
-
-                    // const result = await dialog.showMessageBox({
-                    //     title: 'Additional Action Required',
-                    //     message:
-                    //         'Input created. Click "copy" to copy necessary CSS, then right click the input, go to properties, and paste.',
-                    //     type: 'info',
-                    //     buttons: ['Copy', 'Skip'],
-                    //     defaultId: 0,
-                    // });
-
-                    // if (result.response === 0) {
-                    //     clipboard.writeText('body {background: transparent;}');
-                    // }
-
-                    found = true;
-                }
-            });
-        } catch (err) {
-            // Sadness
-            dialog.showErrorBox('Failed', 'Unable to communicate with vMix');
-        }
-    }
 }

--- a/src/models/AutoAVStatus.ts
+++ b/src/models/AutoAVStatus.ts
@@ -1,0 +1,20 @@
+import { FileNameMode } from '../utils/recording';
+
+// Snapshot of AutoAV's health, surfaced in the Auto AV tab so a volunteer can
+// tell at a glance whether recording is actually working.
+export interface AutoAVStatus {
+    // Connected to the FMS SignalR hub
+    fmsConnected: boolean;
+    // vMix reachability + whether it is currently recording
+    vmix: { reachable: boolean; recording: boolean };
+    // Whether AutoAV itself kicked off the current recording
+    recordingActive: boolean;
+    // The event AutoAV detected as currently running
+    currentEvent: { name: string; code: string | null } | null;
+    // Folder the most recent match was saved into (null until first save)
+    saveFolder: string | null;
+    // Effective file naming mode for this event
+    fileNameMode: FileNameMode;
+    // Last human-readable status line (mirrors the footer)
+    lastMessage: string | null;
+}

--- a/src/models/AutoAVStatus.ts
+++ b/src/models/AutoAVStatus.ts
@@ -3,6 +3,8 @@ import { FileNameMode } from '../utils/recording';
 // Snapshot of AutoAV's health, surfaced in the Auto AV tab so a volunteer can
 // tell at a glance whether recording is actually working.
 export interface AutoAVStatus {
+    // Whether the AutoAV addon thread is running
+    running: boolean;
     // Connected to the FMS SignalR hub
     fmsConnected: boolean;
     // vMix reachability + whether it is currently recording
@@ -11,10 +13,12 @@ export interface AutoAVStatus {
     recordingActive: boolean;
     // The event AutoAV detected as currently running
     currentEvent: { name: string; code: string | null } | null;
-    // Folder the most recent match was saved into (null until first save)
+    // Folder recordings are filed into (the effective event folder)
     saveFolder: string | null;
     // Effective file naming mode for this event
     fileNameMode: FileNameMode;
+    // Example output filename for the current event + naming mode
+    sampleFileName: string;
     // Last human-readable status line (mirrors the footer)
     lastMessage: string | null;
 }

--- a/src/models/FMSMatchState.ts
+++ b/src/models/FMSMatchState.ts
@@ -21,7 +21,11 @@ type MatchState =
     | 'WaitingForMatchPreview'
     | 'WaitingForMatchPreviewTO';
 
-type TournamentLevel = 'Practice' | 'Qualification' | 'Playoff' | 'Match Test';
+export type TournamentLevel =
+    | 'Practice'
+    | 'Qualification'
+    | 'Playoff'
+    | 'Match Test';
 
 // P1: Match State (String), P2: Match Number (Number), P3: Play Number (Number), P4: Level (String)
 type FMSMatchStatus = {

--- a/src/models/MatchRecord.ts
+++ b/src/models/MatchRecord.ts
@@ -1,0 +1,43 @@
+import { TournamentLevel } from './FMSMatchState';
+
+// A single team's participation in a recorded match, including any card issued
+export interface MatchTeam {
+    teamNumber: number;
+    // Effective card for THIS match (from FMS cardEffectiveStatus). A carried
+    // yellow from a previous match is not reflected here (see FmsApi).
+    card: 'None' | 'Yellow' | 'Red';
+}
+
+export type MatchRecordStatus = 'recording' | 'recorded' | 'error';
+
+// Reserved for the v2 cutting step. Not populated yet.
+export interface MatchProcessing {
+    state: 'unprocessed' | 'queued' | 'processing' | 'done' | 'error';
+    outputPath?: string;
+    error?: string;
+}
+
+// Everything AutoAV knows about a match it recorded. Persisted to the
+// 'recordings' store and surfaced in the Auto AV tab.
+export interface MatchRecord {
+    id: string; // `${level}_${matchNumber}_${playNumber}_${startedAt}`
+    level: TournamentLevel;
+    matchNumber: number;
+    playNumber: number;
+    eventName: string;
+    eventCode: string | null;
+    fileName: string | null;
+    filePath: string | null;
+    saveFolder: string | null;
+    startedAt: number; // epoch ms (record start)
+    endedAt: number | null; // epoch ms (record stop)
+    status: MatchRecordStatus;
+    error?: string;
+
+    // v2 metadata (captured now, after the file is renamed)
+    teams?: { red: MatchTeam[]; blue: MatchTeam[] };
+    hasCard?: boolean; // derived: any cardEffectiveStatus !== 'None'
+
+    // v2 processing (reserved, not populated this session)
+    processing?: MatchProcessing;
+}

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -6,7 +6,7 @@ body {
     position: relative;
     min-height: 100vh;
     margin: 0;
-    padding: 8px;
+    padding: 0;
     box-sizing: border-box;
     background-color: #141414;
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
 import { ConfigProvider, theme } from 'antd';
 import './App.css';
-import AppRoutes from './AppRoutes';
+import AppRoutes, { AppRouter } from './AppRoutes';
 import StatusContext, { StatusContextType } from './hooks/status_state';
 import BackendStatusSync from './components/BackendStatusSync';
 import AppFooter from './components/Footer';
+import TabBar from './components/TabBar';
 
 export default function App() {
     const [status, setStatus] = useState<StatusContextType>({
@@ -38,12 +39,19 @@ export default function App() {
             <StatusContext.Provider value={contextValue}>
                 <BackendStatusSync />
 
-                <div
-                    className="pretty-scroll"
-                    style={{ height: 'calc(100vh - 40px)', overflowY: 'auto' }}
-                >
-                    <AppRoutes />
-                </div>
+                <AppRouter>
+                    <TabBar />
+
+                    <div
+                        className="pretty-scroll"
+                        style={{
+                            height: 'calc(100vh - 40px - 44px)',
+                            overflowY: 'auto',
+                        }}
+                    >
+                        <AppRoutes />
+                    </div>
+                </AppRouter>
 
                 <AppFooter />
             </StatusContext.Provider>

--- a/src/renderer/AppRoutes.tsx
+++ b/src/renderer/AppRoutes.tsx
@@ -1,45 +1,40 @@
-import { HashRouter, BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import HWCheck from './pages/hwcheck';
 import Welcome from './pages/welcome';
 import InternetSetup from './pages/internet_setup';
 import Alerts from './pages/alerts';
 import CameraSetup from './pages/camera_setup';
 import FallbackToDocs from './pages/fallbackToDocs';
+import AutoAV from './pages/autoav';
 
-let Router: typeof HashRouter | typeof BrowserRouter;
-if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-    Router = HashRouter;
-} else {
-    Router = HashRouter;
-}
+// Always use the hash router (both dev and prod load from a file/hash URL)
+export const AppRouter = HashRouter;
 
 function AppRoutes() {
     return (
-        <Router>
-            {/* App Routes */}
-            <Routes>
-                <Route path="/" element={<Welcome />} />
-                <Route path="/alerts" element={<Alerts />} />
+        <Routes>
+            <Route path="/" element={<Welcome />} />
+            <Route path="/alerts" element={<Alerts />} />
+            <Route path="/autoav" element={<AutoAV />} />
 
-                {/* Each Step should be defined here, and each step handles itself. Use this to rearrange steps */}
-                <Route
-                    path="/step/1"
-                    element={<HWCheck nextStep={2} previousStep={0} />}
-                />
-                <Route
-                    path="/step/2"
-                    element={<InternetSetup nextStep={3} previousStep={1} />}
-                />
-                <Route
-                    path="/step/3"
-                    element={<CameraSetup nextStep={4} previousStep={2} />}
-                />
-                <Route
-                    path="/step/4"
-                    element={<FallbackToDocs nextStep={4} previousStep={3} />}
-                />
-            </Routes>
-        </Router>
+            {/* Each Step should be defined here, and each step handles itself. Use this to rearrange steps */}
+            <Route
+                path="/step/1"
+                element={<HWCheck nextStep={2} previousStep={0} />}
+            />
+            <Route
+                path="/step/2"
+                element={<InternetSetup nextStep={3} previousStep={1} />}
+            />
+            <Route
+                path="/step/3"
+                element={<CameraSetup nextStep={4} previousStep={2} />}
+            />
+            <Route
+                path="/step/4"
+                element={<FallbackToDocs nextStep={4} previousStep={3} />}
+            />
+        </Routes>
     );
 }
 

--- a/src/renderer/AppRoutes.tsx
+++ b/src/renderer/AppRoutes.tsx
@@ -6,6 +6,8 @@ import Alerts from './pages/alerts';
 import CameraSetup from './pages/camera_setup';
 import FallbackToDocs from './pages/fallbackToDocs';
 import AutoAV from './pages/autoav';
+import LiveCaptions from './pages/livecaptions';
+import Vmix from './pages/vmix';
 
 // Always use the hash router (both dev and prod load from a file/hash URL)
 export const AppRouter = HashRouter;
@@ -16,6 +18,8 @@ function AppRoutes() {
             <Route path="/" element={<Welcome />} />
             <Route path="/alerts" element={<Alerts />} />
             <Route path="/autoav" element={<AutoAV />} />
+            <Route path="/vmix" element={<Vmix />} />
+            <Route path="/livecaptions" element={<LiveCaptions />} />
 
             {/* Each Step should be defined here, and each step handles itself. Use this to rearrange steps */}
             <Route

--- a/src/renderer/components/AddonControlRow.css
+++ b/src/renderer/components/AddonControlRow.css
@@ -1,0 +1,40 @@
+.addon-control-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #303030;
+}
+
+.addon-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.addon-dot--on {
+    background: #52c41a;
+    box-shadow: 0 0 0 3px rgba(82, 196, 26, 0.18);
+}
+
+.addon-dot--off {
+    background: rgba(255, 255, 255, 0.35);
+}
+
+.addon-version {
+    font-family: 'Courier New', monospace;
+    margin: 0;
+}
+
+.addon-version--btn {
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.addon-version--btn:hover {
+    border-color: #1668dc;
+    color: #4c9bff;
+}

--- a/src/renderer/components/AddonControlRow.tsx
+++ b/src/renderer/components/AddonControlRow.tsx
@@ -1,0 +1,143 @@
+import { ReactNode } from 'react';
+import { Button, Space, Tag, Tooltip, Typography } from 'antd';
+import {
+    CaretRightOutlined,
+    ReloadOutlined,
+    SettingOutlined,
+    StopOutlined,
+} from '@ant-design/icons';
+import './AddonControlRow.css';
+
+const { Text } = Typography;
+
+interface AddonControlRowProps {
+    // Status dot + label
+    running: boolean;
+    statusLabel?: string;
+    // Optional version tag; if onVersionClick is set it becomes a button
+    version?: string | null;
+    onVersionClick?: () => void;
+    versionTooltip?: string;
+    // Lifecycle controls - only rendered when the handler is provided
+    onStart?: () => void;
+    onRestart?: () => void;
+    onStop?: () => void;
+    // Settings gear - only rendered when provided
+    onSettings?: () => void;
+    // Disable buttons while an action is in flight
+    busy?: boolean;
+    // Extra actions rendered before the controls
+    extra?: ReactNode;
+}
+
+// The shared second bar under the tab bar: a running indicator, optional
+// version, and optional start/restart/stop + settings. Used by every addon tab
+// so vMix / Live Captions / Auto AV read as one consistent app.
+export default function AddonControlRow({
+    running,
+    statusLabel,
+    version,
+    onVersionClick,
+    versionTooltip,
+    onStart,
+    onRestart,
+    onStop,
+    onSettings,
+    busy = false,
+    extra,
+}: AddonControlRowProps) {
+    const label = statusLabel ?? (running ? 'Running' : 'Stopped');
+
+    const versionTag = version ? (
+        <Tag
+            className={`addon-version${
+                onVersionClick ? ' addon-version--btn' : ''
+            }`}
+            onClick={onVersionClick}
+        >
+            v{version}
+        </Tag>
+    ) : null;
+
+    // Lifecycle controls: start when stopped, restart+stop when running. Only
+    // rendered when all three handlers are provided.
+    let controls: ReactNode = null;
+    if (onStart && onRestart && onStop) {
+        controls = running ? (
+            <>
+                <Button
+                    icon={<ReloadOutlined />}
+                    onClick={onRestart}
+                    loading={busy}
+                >
+                    Restart
+                </Button>
+                <Button
+                    icon={<StopOutlined />}
+                    danger
+                    onClick={onStop}
+                    disabled={busy}
+                >
+                    Stop
+                </Button>
+            </>
+        ) : (
+            <Button
+                type="primary"
+                icon={<CaretRightOutlined />}
+                onClick={onStart}
+                loading={busy}
+            >
+                Start
+            </Button>
+        );
+    }
+
+    return (
+        <div className="addon-control-row">
+            <Space size={10} align="center">
+                <span
+                    className={`addon-dot ${
+                        running ? 'addon-dot--on' : 'addon-dot--off'
+                    }`}
+                />
+                <Text strong>{label}</Text>
+                {version && onVersionClick ? (
+                    <Tooltip
+                        title={versionTooltip ?? 'Click to check for updates'}
+                    >
+                        {versionTag}
+                    </Tooltip>
+                ) : (
+                    versionTag
+                )}
+            </Space>
+
+            <Space size={8}>
+                {extra}
+                {onSettings && (
+                    <Button
+                        icon={<SettingOutlined />}
+                        onClick={onSettings}
+                    >
+                        Settings
+                    </Button>
+                )}
+                {controls}
+            </Space>
+        </div>
+    );
+}
+
+AddonControlRow.defaultProps = {
+    statusLabel: undefined,
+    version: undefined,
+    onVersionClick: undefined,
+    versionTooltip: undefined,
+    onStart: undefined,
+    onRestart: undefined,
+    onStop: undefined,
+    onSettings: undefined,
+    busy: false,
+    extra: undefined,
+};

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -80,7 +80,7 @@ export default function AppFooter() {
 
             <div className="footer-spacer" />
 
-            {/* IP alert badges — right-aligned */}
+            {/* IP alert badges - right-aligned */}
             {ipErrorCount > 0 && (
                 <span className="footer-alert-badge footer-alert-badge--error">
                     <ExclamationCircleOutlined />

--- a/src/renderer/components/StepManager.tsx
+++ b/src/renderer/components/StepManager.tsx
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getStep } from 'renderer/web_utils/step_manager';
 
 function StepManager() {
     const nav = useNavigate();
+    const { pathname } = useLocation();
 
-    // On first load, check the current step from local storage
+    // On first load, resume the saved step. Only redirect from the root so
+    // that landing on another tab (e.g. Auto AV) isn't bounced into the wizard.
     useEffect(() => {
+        if (pathname !== '/') return;
         getStep()
             .then((step) => {
                 if (step > 0) {

--- a/src/renderer/components/TabBar.css
+++ b/src/renderer/components/TabBar.css
@@ -1,0 +1,39 @@
+.tab-bar {
+    display: flex;
+    align-items: stretch;
+    height: 44px;
+    background: #1d1d1d;
+    border-bottom: 1px solid #303030;
+    padding: 0 8px;
+    gap: 4px;
+    -webkit-app-region: drag;
+}
+
+.tab-item {
+    -webkit-app-region: no-drag;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 14px;
+    padding: 0 16px;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.tab-item:hover {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.tab-item--active {
+    color: #fff;
+    border-bottom-color: #1668dc;
+}
+
+.tab-icon {
+    display: inline-flex;
+    font-size: 16px;
+}

--- a/src/renderer/components/TabBar.css
+++ b/src/renderer/components/TabBar.css
@@ -37,3 +37,11 @@
     display: inline-flex;
     font-size: 16px;
 }
+
+.tab-spacer {
+    flex: 1;
+}
+
+.tab-bell {
+    padding: 0 14px;
+}

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -1,6 +1,14 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { SettingOutlined, VideoCameraOutlined } from '@ant-design/icons';
+import { Badge } from 'antd';
+import {
+    BellOutlined,
+    MessageOutlined,
+    RobotOutlined,
+    SettingOutlined,
+    VideoCameraOutlined,
+} from '@ant-design/icons';
+import AlertsResponse from 'models/AlertsResponse';
 import './TabBar.css';
 
 interface TabDef {
@@ -18,9 +26,21 @@ const tabs: TabDef[] = [
         isActive: (p) => p === '/' || p.startsWith('/step'),
     },
     {
+        key: '/vmix',
+        label: 'vMix',
+        icon: <VideoCameraOutlined />,
+        isActive: (p) => p.startsWith('/vmix'),
+    },
+    {
+        key: '/livecaptions',
+        label: 'Live Captions',
+        icon: <MessageOutlined />,
+        isActive: (p) => p.startsWith('/livecaptions'),
+    },
+    {
         key: '/autoav',
         label: 'Auto AV',
-        icon: <VideoCameraOutlined />,
+        icon: <RobotOutlined />,
         isActive: (p) => p.startsWith('/autoav'),
     },
 ];
@@ -28,6 +48,25 @@ const tabs: TabDef[] = [
 export default function TabBar() {
     const nav = useNavigate();
     const { pathname } = useLocation();
+    const [alertCount, setAlertCount] = useState(0);
+
+    // Subscribe to alerts and poll so the bell reflects unread count.
+    useEffect(() => {
+        if (!window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+        const off = ipcRenderer.on('alerts:alerts', (resp: AlertsResponse) =>
+            setAlertCount(resp?.alerts?.length ?? 0)
+        );
+        const poll = () => ipcRenderer.sendMessage('alerts:getAlerts', []);
+        poll();
+        const timer = setInterval(poll, 5000);
+        return () => {
+            off();
+            clearInterval(timer);
+        };
+    }, []);
+
+    const alertsActive = pathname.startsWith('/alerts');
 
     return (
         <div className="tab-bar">
@@ -47,6 +86,21 @@ export default function TabBar() {
                     </button>
                 );
             })}
+
+            <div className="tab-spacer" />
+
+            <button
+                type="button"
+                title="Notifications"
+                className={`tab-item tab-bell${
+                    alertsActive ? ' tab-item--active' : ''
+                }`}
+                onClick={() => nav('/alerts')}
+            >
+                <Badge dot count={alertCount} offset={[2, -2]}>
+                    <BellOutlined className="tab-icon" />
+                </Badge>
+            </button>
         </div>
     );
 }

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { SettingOutlined, VideoCameraOutlined } from '@ant-design/icons';
+import './TabBar.css';
+
+interface TabDef {
+    key: string;
+    label: string;
+    icon: ReactNode;
+    isActive: (_pathname: string) => boolean;
+}
+
+const tabs: TabDef[] = [
+    {
+        key: '/',
+        label: 'Setup',
+        icon: <SettingOutlined />,
+        isActive: (p) => p === '/' || p.startsWith('/step'),
+    },
+    {
+        key: '/autoav',
+        label: 'Auto AV',
+        icon: <VideoCameraOutlined />,
+        isActive: (p) => p.startsWith('/autoav'),
+    },
+];
+
+export default function TabBar() {
+    const nav = useNavigate();
+    const { pathname } = useLocation();
+
+    return (
+        <div className="tab-bar">
+            {tabs.map((t) => {
+                const active = t.isActive(pathname);
+                return (
+                    <button
+                        key={t.key}
+                        type="button"
+                        className={`tab-item${
+                            active ? ' tab-item--active' : ''
+                        }`}
+                        onClick={() => nav(t.key)}
+                    >
+                        <span className="tab-icon">{t.icon}</span>
+                        <span>{t.label}</span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/renderer/pages/autoav/index.css
+++ b/src/renderer/pages/autoav/index.css
@@ -1,0 +1,47 @@
+.autoav-page {
+    padding: 16px 20px 24px;
+    text-align: left;
+}
+
+.autoav-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 720px) {
+    .autoav-cards {
+        grid-template-columns: 1fr;
+    }
+}
+
+.file-name {
+    font-family: 'Courier New', monospace;
+    word-break: break-all;
+}
+
+.team-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.team-trio {
+    display: flex;
+    gap: 8px;
+    font-variant-numeric: tabular-nums;
+}
+
+.team-trio--red span {
+    color: #ff7875;
+}
+
+.team-trio--blue span {
+    color: #69b1ff;
+}
+
+.team-carded {
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}

--- a/src/renderer/pages/autoav/index.css
+++ b/src/renderer/pages/autoav/index.css
@@ -9,6 +9,41 @@
     gap: 12px;
 }
 
+/* Clear panel fill so the status cards sit on the app background like the
+   footer, rather than the raised grey Card surface. */
+.autoav-cards .ant-card {
+    background: transparent;
+}
+
+/* Recording indicator: a red dot while vMix is recording, grey when idle,
+   the way a record light reads in the video world. */
+.rec-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.rec-dot--idle {
+    background: rgba(255, 255, 255, 0.35);
+}
+
+.rec-dot--live {
+    background: #ff4d4f;
+    box-shadow: 0 0 0 0 rgba(255, 77, 79, 0.5);
+    animation: rec-pulse 1.4s ease-out infinite;
+}
+
+@keyframes rec-pulse {
+    from {
+        box-shadow: 0 0 0 0 rgba(255, 77, 79, 0.5);
+    }
+    to {
+        box-shadow: 0 0 0 6px rgba(255, 77, 79, 0);
+    }
+}
+
 @media (max-width: 720px) {
     .autoav-cards {
         grid-template-columns: 1fr;

--- a/src/renderer/pages/autoav/index.tsx
+++ b/src/renderer/pages/autoav/index.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    Badge,
+    Button,
+    Card,
+    Empty,
+    Popconfirm,
+    Space,
+    Table,
+    Tag,
+    Typography,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import {
+    CheckCircleTwoTone,
+    CloseCircleTwoTone,
+    FolderOpenOutlined,
+    VideoCameraOutlined,
+} from '@ant-design/icons';
+import { AutoAVStatus } from 'models/AutoAVStatus';
+import { MatchRecord, MatchTeam } from 'models/MatchRecord';
+import './index.css';
+
+const { Title, Text } = Typography;
+
+const LEVEL_SHORT: Record<string, string> = {
+    Qualification: 'Qual',
+    Playoff: 'Playoff',
+    Practice: 'Practice',
+    'Match Test': 'Test',
+};
+
+function levelShort(level: string): string {
+    return LEVEL_SHORT[level] ?? level;
+}
+
+function matchLabel(m: MatchRecord): string {
+    const play = m.playNumber > 1 ? ` P${m.playNumber}` : '';
+    return `${levelShort(m.level)} ${m.matchNumber}${play}`;
+}
+
+const STATUS_TAG: Record<MatchRecord['status'], { color: string; text: string }> =
+    {
+        recording: { color: 'processing', text: 'Recording' },
+        recorded: { color: 'success', text: 'Recorded' },
+        error: { color: 'error', text: 'Error' },
+    };
+
+// Merge an incoming record into the list (replace by id), newest first.
+function mergeMatch(list: MatchRecord[], rec: MatchRecord): MatchRecord[] {
+    const next = list.filter((m) => m.id !== rec.id);
+    next.push(rec);
+    return next.sort((a, b) => b.startedAt - a.startedAt);
+}
+
+function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+    return (
+        <Space size={6}>
+            {ok ? (
+                <CheckCircleTwoTone twoToneColor="#52c41a" />
+            ) : (
+                <CloseCircleTwoTone twoToneColor="#ff4d4f" />
+            )}
+            <Text>{label}</Text>
+        </Space>
+    );
+}
+
+function TeamCell({ teams }: { teams: MatchRecord['teams'] }) {
+    if (!teams || (teams.red.length === 0 && teams.blue.length === 0)) {
+        return <Text type="secondary">—</Text>;
+    }
+    const renderTrio = (trio: MatchTeam[], className: string) => (
+        <div className={className}>
+            {trio.map((t) => (
+                <span
+                    key={t.teamNumber}
+                    className={t.card !== 'None' ? 'team-carded' : undefined}
+                >
+                    {t.teamNumber}
+                </span>
+            ))}
+        </div>
+    );
+    return (
+        <div className="team-cell">
+            {renderTrio(teams.red, 'team-trio team-trio--red')}
+            {renderTrio(teams.blue, 'team-trio team-trio--blue')}
+        </div>
+    );
+}
+
+function CardCell({ record }: { record: MatchRecord }) {
+    const carded = [
+        ...(record.teams?.red ?? []),
+        ...(record.teams?.blue ?? []),
+    ].filter((t) => t.card !== 'None');
+
+    if (record.teams && carded.length === 0) {
+        return <Text type="secondary">None</Text>;
+    }
+    if (carded.length === 0) {
+        return <Text type="secondary">—</Text>;
+    }
+    return (
+        <Space size={4} wrap>
+            {carded.map((t) => (
+                <Tag
+                    key={t.teamNumber}
+                    color={t.card === 'Red' ? 'red' : 'gold'}
+                >
+                    {t.teamNumber} {t.card}
+                </Tag>
+            ))}
+        </Space>
+    );
+}
+
+export default function AutoAVPage() {
+    const [status, setStatus] = useState<AutoAVStatus | null>(null);
+    const [matches, setMatches] = useState<MatchRecord[]>([]);
+
+    useEffect(() => {
+        if (!window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+
+        const offStatus = ipcRenderer.on(
+            'autoav:status',
+            (s: AutoAVStatus) => setStatus(s)
+        );
+        const offMatches = ipcRenderer.on(
+            'autoav:matches',
+            (list: MatchRecord[]) =>
+                setMatches(
+                    [...list].sort((a, b) => b.startedAt - a.startedAt)
+                )
+        );
+        const offMatch = ipcRenderer.on('autoav:match', (rec: MatchRecord) =>
+            setMatches((prev) => mergeMatch(prev, rec))
+        );
+
+        ipcRenderer.sendMessage('autoav:getState', []);
+
+        return () => {
+            offStatus();
+            offMatches();
+            offMatch();
+        };
+    }, []);
+
+    const recordingMatch = useMemo(
+        () => matches.find((m) => m.status === 'recording'),
+        [matches]
+    );
+
+    const working = !!status?.fmsConnected && !!status?.vmix.reachable;
+
+    const columns: ColumnsType<MatchRecord> = [
+        {
+            title: 'Match',
+            key: 'match',
+            render: (_, m) => <Text strong>{matchLabel(m)}</Text>,
+        },
+        {
+            title: 'Teams (Red / Blue)',
+            key: 'teams',
+            render: (_, m) => <TeamCell teams={m.teams} />,
+        },
+        {
+            title: 'Cards',
+            key: 'cards',
+            render: (_, m) => <CardCell record={m} />,
+        },
+        {
+            title: 'File',
+            key: 'file',
+            render: (_, m) =>
+                m.fileName ? (
+                    <Text
+                        className="file-name"
+                        title={m.filePath ?? undefined}
+                    >
+                        {m.fileName}
+                    </Text>
+                ) : (
+                    <Text type="secondary">—</Text>
+                ),
+        },
+        {
+            title: 'Time',
+            key: 'time',
+            render: (_, m) => (
+                <Text type="secondary">
+                    {new Date(m.startedAt).toLocaleTimeString()}
+                </Text>
+            ),
+        },
+        {
+            title: 'Status',
+            key: 'status',
+            render: (_, m) => {
+                const tag = STATUS_TAG[m.status];
+                return (
+                    <span title={m.error ?? undefined}>
+                        <Tag color={tag.color}>{tag.text}</Tag>
+                    </span>
+                );
+            },
+        },
+    ];
+
+    return (
+        <div className="autoav-page">
+            <Space
+                align="center"
+                style={{
+                    width: '100%',
+                    justifyContent: 'space-between',
+                    marginBottom: 12,
+                }}
+            >
+                <Title level={3} style={{ margin: 0 }}>
+                    <VideoCameraOutlined /> Auto AV
+                </Title>
+                <Badge
+                    status={working ? 'success' : 'error'}
+                    text={working ? 'Working' : 'Not ready'}
+                />
+            </Space>
+
+            <div className="autoav-cards">
+                <Card size="small" title="Status">
+                    <Space direction="vertical" size={8}>
+                        <StatusBadge
+                            ok={!!status?.fmsConnected}
+                            label="FMS connected"
+                        />
+                        <StatusBadge
+                            ok={!!status?.vmix.reachable}
+                            label="vMix reachable"
+                        />
+                        <StatusBadge
+                            ok={!!status?.vmix.recording}
+                            label="vMix recording"
+                        />
+                        {recordingMatch && (
+                            <Text type="warning">
+                                Recording now: {matchLabel(recordingMatch)}
+                            </Text>
+                        )}
+                        {status?.lastMessage && (
+                            <Text type="secondary">{status.lastMessage}</Text>
+                        )}
+                    </Space>
+                </Card>
+
+                <Card size="small" title="Detected event">
+                    <Space direction="vertical" size={8}>
+                        <Text strong>
+                            {status?.currentEvent?.name ?? 'No event detected'}
+                        </Text>
+                        {status?.currentEvent?.code && (
+                            <Text type="secondary">
+                                Code: {status.currentEvent.code}
+                            </Text>
+                        )}
+                        <Text type="secondary">
+                            Naming: {status?.fileNameMode ?? 'in-season'}
+                        </Text>
+                        <Space size={6}>
+                            <FolderOpenOutlined />
+                            <Text
+                                type="secondary"
+                                className="file-name"
+                                title={status?.saveFolder ?? undefined}
+                            >
+                                {status?.saveFolder ??
+                                    'Saved alongside vMix recordings once recording starts'}
+                            </Text>
+                        </Space>
+                    </Space>
+                </Card>
+            </div>
+
+            <Space
+                align="center"
+                style={{
+                    width: '100%',
+                    justifyContent: 'space-between',
+                    margin: '16px 0 8px',
+                }}
+            >
+                <Title level={5} style={{ margin: 0 }}>
+                    Recorded matches ({matches.length})
+                </Title>
+                {matches.length > 0 && (
+                    <Popconfirm
+                        title="Clear recorded match history?"
+                        description="This only clears the list shown here, not the video files."
+                        okText="Clear"
+                        okButtonProps={{ danger: true }}
+                        onConfirm={() =>
+                            window.electron?.ipcRenderer.sendMessage(
+                                'autoav:clearMatches',
+                                []
+                            )
+                        }
+                    >
+                        <Button size="small" danger type="text">
+                            Clear history
+                        </Button>
+                    </Popconfirm>
+                )}
+            </Space>
+
+            {matches.length === 0 ? (
+                <Empty description="No matches recorded yet" />
+            ) : (
+                <Table
+                    rowKey="id"
+                    size="small"
+                    pagination={false}
+                    columns={columns}
+                    dataSource={matches}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/renderer/pages/autoav/index.tsx
+++ b/src/renderer/pages/autoav/index.tsx
@@ -1,24 +1,29 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-    Badge,
     Button,
     Card,
     Empty,
-    Popconfirm,
+    Form,
+    Input,
+    Modal,
+    Select,
     Space,
+    Switch,
     Table,
     Tag,
     Typography,
+    message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
-    CheckCircleTwoTone,
-    CloseCircleTwoTone,
+    CheckCircleFilled,
+    CloseCircleFilled,
     FolderOpenOutlined,
-    VideoCameraOutlined,
+    ScissorOutlined,
 } from '@ant-design/icons';
 import { AutoAVStatus } from 'models/AutoAVStatus';
 import { MatchRecord, MatchTeam } from 'models/MatchRecord';
+import AddonControlRow from '../../components/AddonControlRow';
 import './index.css';
 
 const { Title, Text } = Typography;
@@ -53,22 +58,110 @@ function mergeMatch(list: MatchRecord[], rec: MatchRecord): MatchRecord[] {
     return next.sort((a, b) => b.startedAt - a.startedAt);
 }
 
+function CutCell({ record }: { record: MatchRecord }) {
+    const triggerCut = () =>
+        window.electron?.ipcRenderer.sendMessage('autoav:cutMatch', [
+            record.saveFolder,
+            record.id,
+        ]);
+    const reveal = (target?: string) =>
+        window.electron?.ipcRenderer.sendMessage('autoav:revealFile', [target]);
+
+    // Only recorded matches with a file can be cut.
+    if (record.status !== 'recorded' || !record.filePath) {
+        return <Text type="secondary">-</Text>;
+    }
+
+    // Carded matches are never cut: the card explanation lives in the dead time.
+    if (record.hasCard) {
+        return (
+            <span title="Card issued, kept whole to preserve the explanation">
+                <Tag color="gold">Kept (card)</Tag>
+            </span>
+        );
+    }
+
+    const p = record.processing;
+    if (p?.state === 'queued') {
+        return <Tag>Queued</Tag>;
+    }
+    if (p?.state === 'processing') {
+        return <Tag color="processing">Cutting</Tag>;
+    }
+    if (p?.state === 'done') {
+        return (
+            <Button
+                type="link"
+                size="small"
+                icon={<FolderOpenOutlined />}
+                style={{ padding: 0, height: 'auto' }}
+                title={p.outputPath ?? undefined}
+                onClick={() => reveal(p.outputPath)}
+            >
+                Show cut
+            </Button>
+        );
+    }
+    if (p?.state === 'error') {
+        return (
+            <Space size={8}>
+                <span title={p.error ?? undefined}>
+                    <Tag color="error">Failed</Tag>
+                </span>
+                <Button
+                    type="link"
+                    size="small"
+                    style={{ padding: 0, height: 'auto' }}
+                    onClick={triggerCut}
+                >
+                    Retry
+                </Button>
+            </Space>
+        );
+    }
+    // Not cut yet: offer the manual trigger.
+    return (
+        <Button
+            type="link"
+            size="small"
+            icon={<ScissorOutlined />}
+            style={{ padding: 0, height: 'auto' }}
+            onClick={triggerCut}
+        >
+            Cut
+        </Button>
+    );
+}
+
 function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
     return (
         <Space size={6}>
             {ok ? (
-                <CheckCircleTwoTone twoToneColor="#52c41a" />
+                <CheckCircleFilled style={{ color: '#52c41a' }} />
             ) : (
-                <CloseCircleTwoTone twoToneColor="#ff4d4f" />
+                <CloseCircleFilled style={{ color: '#ff4d4f' }} />
             )}
             <Text>{label}</Text>
         </Space>
     );
 }
 
+function RecordingBadge({ recording }: { recording: boolean }) {
+    return (
+        <Space size={6}>
+            <span
+                className={`rec-dot ${
+                    recording ? 'rec-dot--live' : 'rec-dot--idle'
+                }`}
+            />
+            <Text>vMix recording</Text>
+        </Space>
+    );
+}
+
 function TeamCell({ teams }: { teams: MatchRecord['teams'] }) {
     if (!teams || (teams.red.length === 0 && teams.blue.length === 0)) {
-        return <Text type="secondary">—</Text>;
+        return <Text type="secondary">-</Text>;
     }
     const renderTrio = (trio: MatchTeam[], className: string) => (
         <div className={className}>
@@ -100,7 +193,7 @@ function CardCell({ record }: { record: MatchRecord }) {
         return <Text type="secondary">None</Text>;
     }
     if (carded.length === 0) {
-        return <Text type="secondary">—</Text>;
+        return <Text type="secondary">-</Text>;
     }
     return (
         <Space size={4} wrap>
@@ -116,18 +209,146 @@ function CardCell({ record }: { record: MatchRecord }) {
     );
 }
 
+interface AutoAvSettings {
+    fileNameMode: 'in-season' | 'off-season';
+    eventNameOverride: string;
+    saveFolder: string;
+    autoCut: boolean;
+}
+
+function SettingsDialog({
+    open,
+    onClose,
+}: {
+    open: boolean;
+    onClose: () => void;
+}) {
+    const [form] = Form.useForm<AutoAvSettings>();
+    const [loading, setLoading] = useState(true);
+
+    // Load current settings whenever the dialog opens.
+    useEffect(() => {
+        if (!open || !window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+        setLoading(true);
+        const off = ipcRenderer.on(
+            'autoav:settings',
+            (s: AutoAvSettings) => {
+                form.setFieldsValue(s);
+                setLoading(false);
+            }
+        );
+        ipcRenderer.sendMessage('autoav:getSettings', []);
+        return off;
+    }, [open, form]);
+
+    const pickFolder = useCallback(() => {
+        if (!window.electron) return;
+        const { ipcRenderer } = window.electron;
+        const off = ipcRenderer.on('autoav:folderPicked', (folder: string) => {
+            off();
+            form.setFieldValue('saveFolder', folder);
+        });
+        ipcRenderer.sendMessage('autoav:pickFolder', []);
+    }, [form]);
+
+    const save = useCallback(async () => {
+        const values = await form.validateFields();
+        window.electron?.ipcRenderer.sendMessage('autoav:saveSettings', [
+            values,
+        ]);
+        message.success('Settings saved');
+        onClose();
+    }, [form, onClose]);
+
+    return (
+        <Modal
+            title="Auto AV settings"
+            open={open}
+            onCancel={onClose}
+            onOk={save}
+            okText="Save"
+            confirmLoading={loading}
+            destroyOnClose
+        >
+            <Form
+                form={form}
+                layout="vertical"
+                disabled={loading}
+                style={{ marginTop: 12 }}
+            >
+                <Form.Item
+                    label="Event name"
+                    name="eventNameOverride"
+                    tooltip="Typed here, this always overrides the event name FMS reports and is used in the file name and folder. Leave blank to use FMS."
+                >
+                    <Input placeholder="e.g. Wolverine Robotics Competition" />
+                </Form.Item>
+
+                <Form.Item
+                    label="Save folder"
+                    name="saveFolder"
+                    tooltip="Where renamed match videos are moved. Blank = alongside the vMix recording. A per-event subfolder is created inside this."
+                >
+                    <Input
+                        placeholder="(blank = next to the vMix recording)"
+                        addonAfter={
+                            <Button
+                                type="text"
+                                size="small"
+                                icon={<FolderOpenOutlined />}
+                                onClick={pickFolder}
+                                style={{ height: 'auto', padding: 0 }}
+                            >
+                                Browse
+                            </Button>
+                        }
+                    />
+                </Form.Item>
+
+                <Form.Item
+                    label="File naming style"
+                    name="fileNameMode"
+                    tooltip="Official events force in-season naming automatically; this is the fallback. In-season: QM13_Event.mp4. Off-season: 2026 Event - Qualification Match 13.mp4."
+                >
+                    <Select
+                        options={[
+                            { value: 'in-season', label: 'In-season (short codes)' },
+                            {
+                                value: 'off-season',
+                                label: 'Off-season (readable)',
+                            },
+                        ]}
+                    />
+                </Form.Item>
+
+                <Form.Item
+                    label="Auto-cut dead time"
+                    name="autoCut"
+                    valuePropName="checked"
+                    tooltip="After each match records, remove the dead time and keep the trimmed video in the event folder; the raw original is moved into an Originals subfolder. Matches with a card are always kept whole so the card explanation survives. Re-encodes on this machine, so leave off if vMix needs all the CPU during the event."
+                >
+                    <Switch />
+                </Form.Item>
+            </Form>
+        </Modal>
+    );
+}
+
 export default function AutoAVPage() {
     const [status, setStatus] = useState<AutoAVStatus | null>(null);
     const [matches, setMatches] = useState<MatchRecord[]>([]);
+    const [settingsOpen, setSettingsOpen] = useState(false);
+    const [addonBusy, setAddonBusy] = useState(false);
 
     useEffect(() => {
         if (!window.electron) return undefined;
         const { ipcRenderer } = window.electron;
 
-        const offStatus = ipcRenderer.on(
-            'autoav:status',
-            (s: AutoAVStatus) => setStatus(s)
-        );
+        const offStatus = ipcRenderer.on('autoav:status', (s: AutoAVStatus) => {
+            setStatus(s);
+            setAddonBusy(false);
+        });
         const offMatches = ipcRenderer.on(
             'autoav:matches',
             (list: MatchRecord[]) =>
@@ -152,6 +373,16 @@ export default function AutoAVPage() {
         () => matches.find((m) => m.status === 'recording'),
         [matches]
     );
+
+    const restartAddon = useCallback(() => {
+        setAddonBusy(true);
+        window.electron?.ipcRenderer.sendMessage('autoav:restart', []);
+    }, []);
+
+    const stopAddon = useCallback(() => {
+        setAddonBusy(true);
+        window.electron?.ipcRenderer.sendMessage('autoav:stopAddon', []);
+    }, []);
 
     const working = !!status?.fmsConnected && !!status?.vmix.reachable;
 
@@ -183,7 +414,7 @@ export default function AutoAVPage() {
                         {m.fileName}
                     </Text>
                 ) : (
-                    <Text type="secondary">—</Text>
+                    <Text type="secondary">-</Text>
                 ),
         },
         {
@@ -207,27 +438,29 @@ export default function AutoAVPage() {
                 );
             },
         },
+        {
+            title: 'Cut',
+            key: 'cut',
+            render: (_, m) => <CutCell record={m} />,
+        },
     ];
 
-    return (
-        <div className="autoav-page">
-            <Space
-                align="center"
-                style={{
-                    width: '100%',
-                    justifyContent: 'space-between',
-                    marginBottom: 12,
-                }}
-            >
-                <Title level={3} style={{ margin: 0 }}>
-                    <VideoCameraOutlined /> Auto AV
-                </Title>
-                <Badge
-                    status={working ? 'success' : 'error'}
-                    text={working ? 'Working' : 'Not ready'}
-                />
-            </Space>
+    let statusLabel = 'Stopped';
+    if (working) statusLabel = 'Working';
+    else if (status?.running) statusLabel = 'Running';
 
+    return (
+        <>
+            <AddonControlRow
+                running={!!status?.running}
+                statusLabel={statusLabel}
+                onStart={restartAddon}
+                onRestart={restartAddon}
+                onStop={stopAddon}
+                onSettings={() => setSettingsOpen(true)}
+                busy={addonBusy}
+            />
+            <div className="autoav-page">
             <div className="autoav-cards">
                 <Card size="small" title="Status">
                     <Space direction="vertical" size={8}>
@@ -239,79 +472,64 @@ export default function AutoAVPage() {
                             ok={!!status?.vmix.reachable}
                             label="vMix reachable"
                         />
-                        <StatusBadge
-                            ok={!!status?.vmix.recording}
-                            label="vMix recording"
+                        <RecordingBadge
+                            recording={!!status?.vmix.recording}
                         />
                         {recordingMatch && (
                             <Text type="warning">
                                 Recording now: {matchLabel(recordingMatch)}
                             </Text>
                         )}
-                        {status?.lastMessage && (
-                            <Text type="secondary">{status.lastMessage}</Text>
-                        )}
                     </Space>
                 </Card>
 
-                <Card size="small" title="Detected event">
+                <Card size="small" title="Recording settings">
                     <Space direction="vertical" size={8}>
                         <Text strong>
                             {status?.currentEvent?.name ?? 'No event detected'}
                         </Text>
-                        {status?.currentEvent?.code && (
-                            <Text type="secondary">
-                                Code: {status.currentEvent.code}
-                            </Text>
-                        )}
-                        <Text type="secondary">
-                            Naming: {status?.fileNameMode ?? 'in-season'}
+                        <Text
+                            type="secondary"
+                            className="file-name"
+                            title={status?.sampleFileName || undefined}
+                        >
+                            {status?.sampleFileName
+                                ? `Filename: ${status.sampleFileName}`
+                                : 'Filename: -'}
                         </Text>
-                        <Space size={6}>
-                            <FolderOpenOutlined />
+                        <Space size={6} align="start">
+                            <Button
+                                type="text"
+                                size="small"
+                                icon={<FolderOpenOutlined />}
+                                onClick={() => {
+                                    if (status?.saveFolder) {
+                                        window.electron?.ipcRenderer.sendMessage(
+                                            'autoav:openFolder',
+                                            []
+                                        );
+                                    } else {
+                                        setSettingsOpen(true);
+                                    }
+                                }}
+                                style={{ padding: 0, height: 'auto' }}
+                            />
                             <Text
                                 type="secondary"
                                 className="file-name"
                                 title={status?.saveFolder ?? undefined}
                             >
                                 {status?.saveFolder ??
-                                    'Saved alongside vMix recordings once recording starts'}
+                                    'Set a save folder in Settings, or it appears here after the first recorded match'}
                             </Text>
                         </Space>
                     </Space>
                 </Card>
             </div>
 
-            <Space
-                align="center"
-                style={{
-                    width: '100%',
-                    justifyContent: 'space-between',
-                    margin: '16px 0 8px',
-                }}
-            >
-                <Title level={5} style={{ margin: 0 }}>
-                    Recorded matches ({matches.length})
-                </Title>
-                {matches.length > 0 && (
-                    <Popconfirm
-                        title="Clear recorded match history?"
-                        description="This only clears the list shown here, not the video files."
-                        okText="Clear"
-                        okButtonProps={{ danger: true }}
-                        onConfirm={() =>
-                            window.electron?.ipcRenderer.sendMessage(
-                                'autoav:clearMatches',
-                                []
-                            )
-                        }
-                    >
-                        <Button size="small" danger type="text">
-                            Clear history
-                        </Button>
-                    </Popconfirm>
-                )}
-            </Space>
+            <Title level={5} style={{ margin: '16px 0 8px' }}>
+                Recorded matches ({matches.length})
+            </Title>
 
             {matches.length === 0 ? (
                 <Empty description="No matches recorded yet" />
@@ -324,6 +542,11 @@ export default function AutoAVPage() {
                     dataSource={matches}
                 />
             )}
-        </div>
+            </div>
+            <SettingsDialog
+                open={settingsOpen}
+                onClose={() => setSettingsOpen(false)}
+            />
+        </>
     );
 }

--- a/src/renderer/pages/livecaptions/index.css
+++ b/src/renderer/pages/livecaptions/index.css
@@ -1,0 +1,17 @@
+.livecaptions-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.livecaptions-frame {
+    flex: 1;
+    min-height: 0;
+}
+
+.livecaptions-frame iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: #fff;
+}

--- a/src/renderer/pages/livecaptions/index.tsx
+++ b/src/renderer/pages/livecaptions/index.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Empty, Modal, message } from 'antd';
+import AddonControlRow from '../../components/AddonControlRow';
+import './index.css';
+
+interface LiveCaptionsStatus {
+    running: boolean;
+    version: string;
+}
+
+const SETTINGS_URL = 'http://localhost:3000/settings.html';
+
+export default function LiveCaptionsPage() {
+    const [status, setStatus] = useState<LiveCaptionsStatus | null>(null);
+    const [busy, setBusy] = useState(false);
+
+    // Subscribe to status and poll it while the tab is mounted.
+    useEffect(() => {
+        if (!window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+        const off = ipcRenderer.on(
+            'liveCaptions:status',
+            (s: LiveCaptionsStatus) => {
+                setStatus(s);
+                setBusy(false);
+            }
+        );
+        const poll = () =>
+            ipcRenderer.sendMessage('liveCaptions:getStatus', []);
+        poll();
+        const timer = setInterval(poll, 3000);
+        return () => {
+            off();
+            clearInterval(timer);
+        };
+    }, []);
+
+    const restart = useCallback(() => {
+        setBusy(true);
+        // The main process only reports running once the server actually answers
+        // on :3000, so the iframe (mounted on running) loads a live server, not
+        // a blank one. No blind reload timer needed.
+        window.electron?.ipcRenderer.sendMessage('liveCaptions:restart', []);
+    }, []);
+
+    // Version click → check for updates; toast if latest, confirm dialog if not.
+    const checkUpdate = useCallback(() => {
+        if (!window.electron) return;
+        const { ipcRenderer } = window.electron;
+        const off = ipcRenderer.on(
+            'liveCaptions:updateInfo',
+            (info: {
+                current: string;
+                latest: string;
+                updateAvailable: boolean;
+            }) => {
+                off();
+                if (!info.updateAvailable) {
+                    message.success(
+                        `Live Captions is up to date (v${info.current})`
+                    );
+                    return;
+                }
+                Modal.confirm({
+                    title: 'Update Live Captions?',
+                    content: `A new version is available (v${info.current} → v${info.latest}). Updating now restarts Live Captions and will briefly interrupt captions.`,
+                    okText: 'Update now',
+                    cancelText: 'Not now',
+                    onOk: () => {
+                        setBusy(true);
+                        ipcRenderer.sendMessage('liveCaptions:update', []);
+                        message.info('Updating Live Captions');
+                    },
+                });
+            }
+        );
+        ipcRenderer.sendMessage('liveCaptions:checkUpdate', []);
+    }, []);
+
+    const stop = useCallback(() => {
+        setBusy(true);
+        window.electron?.ipcRenderer.sendMessage('liveCaptions:stop', []);
+    }, []);
+
+    const running = !!status?.running;
+
+    return (
+        <div className="livecaptions-page">
+            <AddonControlRow
+                running={running}
+                version={status?.version}
+                onVersionClick={checkUpdate}
+                versionTooltip="Click to check for updates"
+                onStart={restart}
+                onRestart={restart}
+                onStop={stop}
+                busy={busy}
+            />
+
+            <div className="livecaptions-frame">
+                {running ? (
+                    <iframe title="Live Captions settings" src={SETTINGS_URL} />
+                ) : (
+                    <Empty
+                        description="Live Captions is stopped. Press Start to launch it and load its settings."
+                        style={{ marginTop: 64 }}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/renderer/pages/vmix/index.css
+++ b/src/renderer/pages/vmix/index.css
@@ -1,0 +1,79 @@
+.vmix-page {
+    padding: 16px 20px 24px;
+    text-align: left;
+}
+
+.vmix-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 720px) {
+    .vmix-cards {
+        grid-template-columns: 1fr;
+    }
+}
+
+.vmix-cards .ant-card {
+    background: transparent;
+}
+
+.vmix-status-icon {
+    color: rgba(255, 255, 255, 0.55);
+    display: inline-flex;
+}
+
+.vmix-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.vmix-dot--off {
+    background: rgba(255, 255, 255, 0.35);
+}
+
+.vmix-dot--on {
+    box-shadow: 0 0 0 3px rgba(255, 77, 79, 0.18);
+}
+
+.vmix-dim {
+    font-size: 12px;
+}
+
+.vmix-stream-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.vmix-stream-total {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding-top: 8px;
+    margin-top: 2px;
+}
+
+.vmix-spark-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.vmix-sparkline {
+    display: block;
+}
+
+.vmix-key-mismatch {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    border: 1px solid rgba(255, 77, 79, 0.3);
+    background: rgba(255, 77, 79, 0.1);
+    border-radius: 6px;
+}

--- a/src/renderer/pages/vmix/index.tsx
+++ b/src/renderer/pages/vmix/index.tsx
@@ -1,0 +1,601 @@
+import { ReactNode, useCallback, useEffect, useState } from 'react';
+import {
+    Button,
+    Card,
+    Form,
+    Input,
+    Modal,
+    Select,
+    Space,
+    Spin,
+    Tag,
+    Typography,
+    message,
+} from 'antd';
+import {
+    ApiOutlined,
+    AudioOutlined,
+    CheckCircleFilled,
+    CloseCircleFilled,
+    DesktopOutlined,
+    KeyOutlined,
+    VideoCameraOutlined,
+} from '@ant-design/icons';
+import AddonControlRow from '../../components/AddonControlRow';
+import './index.css';
+
+const { Title, Text } = Typography;
+
+interface VmixApi {
+    baseUrl: string;
+    username: string;
+    password: string;
+}
+
+interface StreamKeys {
+    eventCode: string;
+    eventName: string;
+    setAt: number;
+}
+
+interface KeyValidation {
+    checked: boolean;
+    match: boolean | null;
+    cloudKeys: string[];
+    runningKeys: string[];
+}
+
+interface VmixStatus {
+    reachable: boolean;
+    recording: boolean;
+    streaming: boolean;
+    currentEvent: { name: string; code: string | null } | null;
+    streamKeys: StreamKeys | null;
+    keysSetForEvent: boolean;
+    keyValidation: KeyValidation;
+}
+
+// Show only the tail of a stream key so we don't splash the full secret.
+function keyTail(k: string): string {
+    return k.length > 6 ? `****${k.slice(-6)}` : k;
+}
+
+interface VmixStream {
+    index: number;
+    targetKbps: number | null;
+    maxrateKbps: number | null;
+    liveKbps: number | null;
+    destination: string;
+}
+
+interface VmixBandwidth {
+    streams: VmixStream[];
+    supported: boolean;
+    warming?: boolean;
+}
+
+// Adaptive bitrate label: kbps under 1 Mbps (static screens are tens of kbps),
+// Mbps with two decimals above.
+function fmtBitrate(kbps: number | null): string {
+    if (kbps == null) return '-';
+    if (kbps < 1000) return `${kbps.toFixed(0)} kbps`;
+    return `${(kbps / 1000).toFixed(2)} Mbps`;
+}
+
+// Minimal inline sparkline of combined stream bitrate over time.
+function Sparkline({ data, width = 240, height = 36 }: {
+    data: number[];
+    width?: number;
+    height?: number;
+}) {
+    if (data.length < 2) {
+        return (
+            <Text type="secondary" className="vmix-dim">
+                gathering samples
+            </Text>
+        );
+    }
+    const max = Math.max(...data, 1);
+    const min = Math.min(...data, 0);
+    const range = max - min || 1;
+    const step = width / (data.length - 1);
+    const points = data
+        .map((v, i) => {
+            const x = i * step;
+            const y = height - ((v - min) / range) * height;
+            return `${x.toFixed(1)},${y.toFixed(1)}`;
+        })
+        .join(' ');
+    return (
+        <svg width={width} height={height} className="vmix-sparkline">
+            <polyline
+                fill="none"
+                stroke="#ff4d4f"
+                strokeWidth="1.5"
+                points={points}
+            />
+        </svg>
+    );
+}
+
+Sparkline.defaultProps = {
+    width: 240,
+    height: 36,
+};
+
+function Dot({ on, color = '#52c41a' }: { on: boolean; color?: string }) {
+    return (
+        <span
+            className={`vmix-dot ${on ? 'vmix-dot--on' : 'vmix-dot--off'}`}
+            style={on ? { background: color } : undefined}
+        />
+    );
+}
+
+Dot.defaultProps = {
+    color: '#52c41a',
+};
+
+function StatusLine({
+    on,
+    label,
+    icon,
+}: {
+    on: boolean;
+    label: string;
+    icon: ReactNode;
+}) {
+    return (
+        <Space size={8}>
+            {on ? (
+                <CheckCircleFilled style={{ color: '#52c41a' }} />
+            ) : (
+                <CloseCircleFilled style={{ color: 'rgba(255,255,255,0.35)' }} />
+            )}
+            <span className="vmix-status-icon">{icon}</span>
+            <Text>{label}</Text>
+        </Space>
+    );
+}
+
+export default function VmixPage() {
+    const [status, setStatus] = useState<VmixStatus | null>(null);
+    const [bandwidth, setBandwidth] = useState<VmixBandwidth | null>(null);
+    const [history, setHistory] = useState<number[]>([]);
+    const [form] = Form.useForm<VmixApi>();
+    const [testing, setTesting] = useState(false);
+    const [settingKeys, setSettingKeys] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
+    const [compositeOpen, setCompositeOpen] = useState(false);
+    const [inputs, setInputs] = useState<
+        { key: string; number: number; title: string; type: string }[]
+    >([]);
+    const [cameraKey, setCameraKey] = useState<string | undefined>();
+    const [fmsKey, setFmsKey] = useState<string | undefined>();
+    const [comp, setComp] = useState({
+        layer: 1,
+        zoom: 0.4398,
+        panX: -0.421,
+        panY: 0.5061,
+    });
+    const MAX_HISTORY = 60;
+
+    // Poll status and load settings on mount.
+    useEffect(() => {
+        if (!window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+
+        const offStatus = ipcRenderer.on('vmix:status', (s: VmixStatus) =>
+            setStatus(s)
+        );
+        const offBandwidth = ipcRenderer.on(
+            'vmix:bandwidth',
+            (b: VmixBandwidth) => {
+                setBandwidth(b);
+                // Combined live (instantaneous) bitrate across streams, in Mbps.
+                const combined = b.streams.reduce(
+                    (sum, s) => sum + (s.liveKbps ?? 0),
+                    0
+                );
+                setHistory((h) =>
+                    [...h, combined / 1000].slice(-MAX_HISTORY)
+                );
+            }
+        );
+        const offSettings = ipcRenderer.on('vmix:settings', (s: VmixApi) =>
+            form.setFieldsValue(s)
+        );
+        const offAction = ipcRenderer.on(
+            'vmix:action',
+            (r: { ok: boolean; message: string; action?: string }) => {
+                if (r.action === 'setStreamKeys') setSettingKeys(false);
+                if (r.ok) message.success(r.message);
+                else message.error(r.message);
+            }
+        );
+
+        const poll = () => {
+            ipcRenderer.sendMessage('vmix:getStatus', []);
+            ipcRenderer.sendMessage('vmix:getBandwidth', []);
+        };
+        // Key validation hits the admin hub, so poll it slowly (every 30s).
+        const pollKeys = () => ipcRenderer.sendMessage('vmix:pollKeys', []);
+        ipcRenderer.sendMessage('vmix:getSettings', []);
+        poll();
+        pollKeys();
+        const timer = setInterval(poll, 3000);
+        const keyTimer = setInterval(pollKeys, 300000);
+
+        return () => {
+            offStatus();
+            offBandwidth();
+            offSettings();
+            offAction();
+            clearInterval(timer);
+            clearInterval(keyTimer);
+        };
+    }, [form]);
+
+    const test = useCallback(() => {
+        if (!window.electron) return;
+        const { ipcRenderer } = window.electron;
+        setTesting(true);
+        const off = ipcRenderer.on(
+            'vmix:testResult',
+            (r: { ok: boolean; message: string }) => {
+                off();
+                setTesting(false);
+                if (r.ok) message.success(r.message);
+                else message.error(r.message);
+            }
+        );
+        ipcRenderer.sendMessage('vmix:testConnection', [
+            form.getFieldsValue(),
+        ]);
+    }, [form]);
+
+    const saveConn = useCallback(async () => {
+        const values = await form.validateFields();
+        window.electron?.ipcRenderer.sendMessage('vmix:saveSettings', [values]);
+        message.success('vMix connection saved');
+        setSettingsOpen(false);
+    }, [form]);
+
+    const send = (channel: string) =>
+        window.electron?.ipcRenderer.sendMessage(channel, []);
+
+    const setStreamKeys = useCallback(() => {
+        setSettingKeys(true);
+        window.electron?.ipcRenderer.sendMessage('vmix:setStreamKeys', []);
+    }, []);
+
+    // Load inputs + saved geometry when the composite dialog opens.
+    useEffect(() => {
+        if (!compositeOpen || !window.electron) return undefined;
+        const { ipcRenderer } = window.electron;
+        const offInputs = ipcRenderer.on(
+            'vmix:inputs',
+            (list: typeof inputs) => {
+                setInputs(list);
+                // Default the FMS layer to an audience-display / FMS input.
+                setFmsKey(
+                    (prev) =>
+                        prev ??
+                        list.find((i) =>
+                            /audience|fms|display/i.test(i.title)
+                        )?.key
+                );
+            }
+        );
+        const offComp = ipcRenderer.on('vmix:composite', (c: typeof comp) =>
+            setComp(c)
+        );
+        ipcRenderer.sendMessage('vmix:getInputs', []);
+        ipcRenderer.sendMessage('vmix:getComposite', []);
+        return () => {
+            offInputs();
+            offComp();
+        };
+    }, [compositeOpen]);
+
+    const applyComposite = useCallback(() => {
+        if (!cameraKey || !fmsKey) {
+            message.error('Pick both the FMS input and the camera');
+            return;
+        }
+        window.electron?.ipcRenderer.sendMessage('vmix:applyComposite', [
+            { cameraKey, fmsKey, ...comp },
+        ]);
+        setCompositeOpen(false);
+    }, [cameraKey, fmsKey, comp]);
+
+    const reachable = !!status?.reachable;
+    const event = status?.currentEvent;
+
+    return (
+        <>
+            <AddonControlRow
+                running={reachable}
+                statusLabel={reachable ? 'Connected' : 'Not connected'}
+                onSettings={() => setSettingsOpen(true)}
+            />
+            <div className="vmix-page">
+            <div className="vmix-cards">
+                <Card size="small" title="Status">
+                    <Space direction="vertical" size={10}>
+                        <StatusLine
+                            on={reachable}
+                            label="vMix reachable"
+                            icon={<ApiOutlined />}
+                        />
+                        <Space size={8}>
+                            <Dot on={!!status?.recording} color="#ff4d4f" />
+                            <VideoCameraOutlined className="vmix-status-icon" />
+                            <Text>
+                                {status?.recording
+                                    ? 'Recording'
+                                    : 'Not recording'}
+                            </Text>
+                        </Space>
+                        <Space size={8}>
+                            <Dot on={!!status?.streaming} color="#ff4d4f" />
+                            <DesktopOutlined className="vmix-status-icon" />
+                            <Text>
+                                {status?.streaming
+                                    ? 'Streaming (live)'
+                                    : 'Not streaming'}
+                            </Text>
+                        </Space>
+                    </Space>
+                </Card>
+
+                <Card size="small" title="Stream keys">
+                    <Space direction="vertical" size={10}>
+                        {status?.keysSetForEvent ? (
+                            <Tag color="success" icon={<KeyOutlined />}>
+                                Set for this event
+                            </Tag>
+                        ) : (
+                            <Tag color="warning" icon={<KeyOutlined />}>
+                                Not set for this event
+                            </Tag>
+                        )}
+                        <Text type="secondary">
+                            Current event: {event?.name ?? 'None detected'}
+                        </Text>
+                        {status?.streamKeys && (
+                            <Text type="secondary" className="vmix-dim">
+                                Last set for {status.streamKeys.eventName}
+                            </Text>
+                        )}
+
+                        {status?.keyValidation?.match === false && (
+                            <div className="vmix-key-mismatch">
+                                <Text type="danger" strong>
+                                    ⚠ Admin key doesn&apos;t match vMix
+                                </Text>
+                                <Text type="secondary" className="vmix-dim">
+                                    vMix using:{' '}
+                                    {status.keyValidation.runningKeys
+                                        .map(keyTail)
+                                        .join(', ') || '-'}
+                                </Text>
+                                <Text type="secondary" className="vmix-dim">
+                                    admin now:{' '}
+                                    {status.keyValidation.cloudKeys
+                                        .map(keyTail)
+                                        .join(', ') || '-'}
+                                </Text>
+                                <Text type="secondary" className="vmix-dim">
+                                    → press Set stream keys
+                                </Text>
+                            </div>
+                        )}
+                        {status?.keyValidation?.match === true && (
+                            <Text type="success">
+                                ✓ Key matches admin
+                            </Text>
+                        )}
+
+                        <Button
+                            icon={<KeyOutlined />}
+                            disabled={!reachable || settingKeys}
+                            loading={settingKeys}
+                            onClick={setStreamKeys}
+                        >
+                            {settingKeys ? 'Setting keys' : 'Set stream keys'}
+                        </Button>
+                    </Space>
+                </Card>
+            </div>
+
+            <Title level={5} style={{ margin: '16px 0 8px' }}>
+                Streaming bandwidth
+            </Title>
+            <Card size="small">
+                {(() => {
+                    if (
+                        bandwidth == null ||
+                        (bandwidth.warming &&
+                            bandwidth.streams.length === 0)
+                    ) {
+                        return (
+                            <Space size={10}>
+                                <Spin size="small" />
+                                <Text type="secondary">
+                                    Loading streaming stats
+                                </Text>
+                            </Space>
+                        );
+                    }
+                    if (bandwidth.streams.length === 0) {
+                        return (
+                            <Text type="secondary">No active streams.</Text>
+                        );
+                    }
+                    return (
+                    <Space
+                        direction="vertical"
+                        size={8}
+                        style={{ width: '100%' }}
+                    >
+                        {bandwidth.streams.map((s) => (
+                            <div key={s.index} className="vmix-stream-row">
+                                <Space size={8}>
+                                    <Dot on color="#ff4d4f" />
+                                    <Text strong>Stream {s.index}</Text>
+                                    <Tag>{s.destination}</Tag>
+                                </Space>
+                                <Text>
+                                    <Text strong>{fmtBitrate(s.liveKbps)}</Text>
+                                    <Text type="secondary" className="vmix-dim">
+                                        {' '}
+                                        / target {fmtBitrate(s.targetKbps)}
+                                    </Text>
+                                </Text>
+                            </div>
+                        ))}
+
+                        <div className="vmix-spark-row">
+                            <Text type="secondary" className="vmix-dim">
+                                Combined live bitrate
+                            </Text>
+                            <Space size={10}>
+                                <Sparkline data={history} />
+                                <Text strong>
+                                    {fmtBitrate(
+                                        bandwidth.streams.reduce(
+                                            (sum, s) => sum + (s.liveKbps ?? 0),
+                                            0
+                                        )
+                                    )}
+                                </Text>
+                            </Space>
+                        </div>
+                    </Space>
+                    );
+                })()}
+            </Card>
+
+            <Title level={5} style={{ margin: '16px 0 8px' }}>
+                vMix inputs
+            </Title>
+            <Space wrap>
+                <Button
+                    icon={<AudioOutlined />}
+                    disabled={!reachable}
+                    onClick={() => send('vmix:addLiveCaptionsInput')}
+                >
+                    Add Live Captions input
+                </Button>
+                <Button
+                    icon={<DesktopOutlined />}
+                    disabled={!reachable}
+                    onClick={() => send('vmix:addAudienceDisplayInput')}
+                >
+                    Add Audience Display input
+                </Button>
+                <Button
+                    icon={<VideoCameraOutlined />}
+                    disabled={!reachable}
+                    onClick={() => setCompositeOpen(true)}
+                >
+                    Add Alliance Selection Composite
+                </Button>
+            </Space>
+
+            <Modal
+                title="Alliance Selection Composite"
+                open={compositeOpen}
+                onCancel={() => setCompositeOpen(false)}
+                onOk={applyComposite}
+                okText="Apply"
+                width={520}
+            >
+                <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                    <Text type="secondary">
+                        Creates an &quot;Alliance Selection Composite&quot; input:
+                        a blank base with your FMS/AD input as layer 1 and the
+                        camera on top as layer 2, sized to the official AD camera
+                        box. Your existing inputs are referenced, not duplicated.
+                    </Text>
+                    <div>
+                        <Text>FMS / audience display input</Text>
+                        <Select
+                            style={{ width: '100%' }}
+                            placeholder="Select FMS/AD input"
+                            value={fmsKey}
+                            onChange={setFmsKey}
+                            options={inputs.map((i) => ({
+                                value: i.key,
+                                label: `${i.number}. ${i.title}`,
+                            }))}
+                        />
+                    </div>
+                    <div>
+                        <Text>Main camera input</Text>
+                        <Select
+                            style={{ width: '100%' }}
+                            placeholder="Select camera"
+                            value={cameraKey}
+                            onChange={setCameraKey}
+                            options={inputs.map((i) => ({
+                                value: i.key,
+                                label: `${i.number}. ${i.title}`,
+                            }))}
+                        />
+                    </div>
+                </Space>
+            </Modal>
+
+            <Modal
+                title="vMix connection"
+                open={settingsOpen}
+                onCancel={() => setSettingsOpen(false)}
+                footer={null}
+            >
+                <Form
+                    form={form}
+                    layout="vertical"
+                    style={{ marginTop: 12 }}
+                >
+                    <Form.Item
+                        label="Web API URL"
+                        name="baseUrl"
+                        rules={[
+                            { required: true, message: 'Enter the vMix API URL' },
+                        ]}
+                        tooltip="vMix defaults to http://127.0.0.1:8088/api"
+                    >
+                        <Input placeholder="http://127.0.0.1:8088/api" />
+                    </Form.Item>
+                    <Space size={12} style={{ display: 'flex' }}>
+                        <Form.Item
+                            label="Username"
+                            name="username"
+                            style={{ flex: 1 }}
+                        >
+                            <Input placeholder="(blank if web auth is off)" />
+                        </Form.Item>
+                        <Form.Item
+                            label="Password"
+                            name="password"
+                            style={{ flex: 1 }}
+                        >
+                            <Input.Password placeholder="(blank if web auth is off)" />
+                        </Form.Item>
+                    </Space>
+                    <Space>
+                        <Button onClick={test} loading={testing}>
+                            Test connection
+                        </Button>
+                        <Button type="primary" onClick={saveConn}>
+                            Save
+                        </Button>
+                    </Space>
+                </Form>
+            </Modal>
+            </div>
+        </>
+    );
+}

--- a/src/services/FmsApi.ts
+++ b/src/services/FmsApi.ts
@@ -1,0 +1,106 @@
+import nodeFetch from 'node-fetch';
+import log from 'electron-log';
+import { TournamentLevel } from '../models/FMSMatchState';
+import { MatchTeam } from '../models/MatchRecord';
+import { isDoubleElimFinal } from '../utils/recording';
+
+const FMS_BASE = 'http://10.0.100.5';
+
+export interface MatchResults {
+    teams: { red: MatchTeam[]; blue: MatchTeam[] };
+    hasCard: boolean;
+}
+
+// Shape of the relevant bits of the FMS GetMatchResults* responses. FMS returns
+// far more than this; we only read teams + effective card status.
+interface FmsTeamResult {
+    teamNumber?: number;
+    cardEffectiveStatus?: string;
+}
+interface FmsAllianceData {
+    team1?: FmsTeamResult;
+    team2?: FmsTeamResult;
+    team3?: FmsTeamResult;
+}
+interface FmsMatchResults {
+    redAllianceData?: FmsAllianceData;
+    blueAllianceData?: FmsAllianceData;
+}
+
+function normalizeCard(status?: string): MatchTeam['card'] {
+    if (status === 'Yellow' || status === 'Red') return status;
+    return 'None';
+}
+
+function mapAlliance(alliance?: FmsAllianceData): MatchTeam[] {
+    if (!alliance) return [];
+    return [alliance.team1, alliance.team2, alliance.team3]
+        .filter((t): t is FmsTeamResult => !!t && typeof t.teamNumber === 'number')
+        .map((t) => ({
+            teamNumber: t.teamNumber as number,
+            card: normalizeCard(t.cardEffectiveStatus),
+        }));
+}
+
+// Pick the FMS match-results endpoint for a given level/match number. Practice
+// and Match Test have no results endpoint. Returns null when there is nothing
+// to fetch.
+function resultsEndpoint(
+    level: TournamentLevel,
+    matchNumber: number
+): string | null {
+    switch (level) {
+        case 'Qualification':
+            return `/api/v1.0/audience_gs/get/GetMatchResultsQualData/${matchNumber}`;
+        case 'Playoff':
+            return isDoubleElimFinal(matchNumber)
+                ? `/api/v1.0/audience_gs/get/GetMatchResultsDoubleElimFinalData/${matchNumber}`
+                : `/api/v1.0/audience_gs/get/GetMatchResultsDoubleElimPlayoffData/${matchNumber}`;
+        default:
+            return null;
+    }
+}
+
+export default class FmsApi {
+    private static instance: FmsApi;
+
+    /**
+     * Fetch the finished-match results (teams + effective card status) for a
+     * match. Best-effort: returns null on any error or unsupported level, never
+     * throws, so it can safely run after a recording is renamed without risking
+     * the file.
+     */
+    // eslint-disable-next-line class-methods-use-this
+    public async getMatchResults(
+        level: TournamentLevel,
+        matchNumber: number
+    ): Promise<MatchResults | null> {
+        const endpoint = resultsEndpoint(level, matchNumber);
+        if (!endpoint) return null;
+
+        try {
+            const resp = await nodeFetch(`${FMS_BASE}${endpoint}`, {
+                timeout: 5000,
+            });
+            if (!resp.ok) {
+                log.warn(
+                    `FmsApi: ${endpoint} returned ${resp.status} ${resp.statusText}`
+                );
+                return null;
+            }
+            const data = (await resp.json()) as FmsMatchResults;
+            const red = mapAlliance(data.redAllianceData);
+            const blue = mapAlliance(data.blueAllianceData);
+            const hasCard = [...red, ...blue].some((t) => t.card !== 'None');
+            return { teams: { red, blue }, hasCard };
+        } catch (err) {
+            log.warn(`FmsApi: failed to fetch ${endpoint}`, err);
+            return null;
+        }
+    }
+
+    public static get Instance(): FmsApi {
+        if (!this.instance) this.instance = new this();
+        return this.instance;
+    }
+}

--- a/src/services/VmixService.ts
+++ b/src/services/VmixService.ts
@@ -154,6 +154,122 @@ export default class VmixService {
         return chain;
     }
 
+    // List inputs (key + number + title + type) for pickers like the alliance
+    // composite camera selector.
+    async GetInputs(): Promise<
+        { key: string; number: number; title: string; type: string }[]
+    > {
+        const parsed = await this.GetBase();
+        const raw = parsed?.vmix?.inputs?.input;
+        const list = Array.isArray(raw) ? raw : [raw].filter(Boolean);
+        return list.map((i: any) => ({
+            key: i.key,
+            number: Number(i.number),
+            title: i.title,
+            type: i.type,
+        }));
+    }
+
+    private vmixCall(inputKey: string, fn: string, value: string) {
+        return fetch(
+            `${this.settings.baseUrl}?Function=${fn}&Input=${encodeURIComponent(
+                inputKey
+            )}&Value=${encodeURIComponent(value)}`,
+            { headers: this.createHeaders() }
+        );
+    }
+
+    async AddColourInput(): Promise<void> {
+        // vMix needs the pipe + hex colour: "Colour|#RRGGBB". Bare "Colour" is
+        // rejected and silently adds nothing.
+        await fetch(
+            `${this.settings.baseUrl}?Function=AddInput&Value=${encodeURIComponent(
+                'Colour|#000000'
+            )}`,
+            { headers: this.createHeaders() }
+        );
+    }
+
+    // Create (or reuse) a dedicated "Alliance Selection Composite" input built
+    // the way the custom AD does it: a blank colour input as the base (layer 0),
+    // the EXISTING FMS/audience-display input as layer 1 (full frame), and the
+    // selected camera as layer 2, positioned at the alliance-selection camera
+    // box. The operator's own FMS/camera inputs are referenced as layers, not
+    // duplicated. vMix 27+ SetLayer<N>Zoom/PanX/PanY does the positioning.
+    async CreateAllianceComposite(
+        fmsKey: string,
+        cameraKey: string,
+        zoom: number,
+        panX: number,
+        panY: number
+    ): Promise<string> {
+        const NAME = 'Alliance Selection Composite';
+        let inputs = await this.GetInputs();
+        let comp = inputs.find((i) => i.title === NAME);
+
+        if (!comp) {
+            const before = new Set(inputs.map((i) => i.key));
+            await this.AddColourInput();
+            // vMix registers the new input asynchronously; poll briefly for it.
+            let added;
+            for (let attempt = 0; attempt < 6 && !added; attempt += 1) {
+                // eslint-disable-next-line no-await-in-loop
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 300);
+                });
+                // eslint-disable-next-line no-await-in-loop
+                inputs = await this.GetInputs();
+                added = inputs.find((i) => !before.has(i.key));
+            }
+            if (!added)
+                throw new Error(
+                    'vMix did not add the colour input (check the vMix API is reachable)'
+                );
+            await this.RenameInput(added.key, NAME);
+            inputs = await this.GetInputs();
+            comp = inputs.find((i) => i.title === NAME) ?? added;
+        }
+        if (!comp) throw new Error('Could not create the composite input');
+
+        // Assign the layers. SetMultiViewOverlay places an input onto a layer of
+        // the target input (Value = "<layer>,<inputKey>"); MultiViewOverlay is
+        // only a visibility toggle and takes just the layer number, which is why
+        // the earlier attempt created the input but left it empty.
+        // Layer 1 = FMS/AD (full frame), Layer 2 = camera (positioned).
+        await this.vmixCall(comp.key, 'SetMultiViewOverlay', `1,${fmsKey}`);
+        await this.vmixCall(comp.key, 'SetMultiViewOverlay', `2,${cameraKey}`);
+        await this.vmixCall(comp.key, 'SetLayer2Zoom', String(zoom));
+        await this.vmixCall(comp.key, 'SetLayer2PanX', String(panX));
+        await this.vmixCall(comp.key, 'SetLayer2PanY', String(panY));
+        return comp.key;
+    }
+
+    // Fetch vMix's configured recording folder so the Auto AV tab can show the
+    // exact save path before any recording. vMix reports the record destination
+    // as recording.filename1 (the directory it will write into).
+    async GetRecordingFolder(): Promise<string | null> {
+        const parsed = await this.GetBase();
+        const rec = parsed?.vmix?.recording;
+        // Attributes surface as properties (attributeNamePrefix: '').
+        const file = rec?.filename1 ?? rec?.filename ?? rec?.setup;
+        if (typeof file === 'string' && file.trim()) {
+            const idx = Math.max(file.lastIndexOf('\\'), file.lastIndexOf('/'));
+            return idx > 0 ? file.slice(0, idx) : file;
+        }
+        return null;
+    }
+
+    // Reload a browser input by its (renamed) title, e.g. after live-captions
+    // updated so the embedded page picks up the new build.
+    async ReloadBrowserInput(name: string): Promise<void> {
+        await fetch(
+            `${this.settings.baseUrl}?Function=BrowserReload&Input=${encodeURIComponent(
+                name
+            )}`,
+            { headers: this.createHeaders() }
+        );
+    }
+
     async AddBrowserInput(url: string): Promise<void> {
         await fetch(
             `${this.settings.baseUrl}?Function=AddInput&Value=Browser|${url}`,
@@ -186,6 +302,48 @@ export default class VmixService {
         });
     }
 
+    // Add a browser input pointing at the given URL, then rename the freshly
+    // created input (vMix titles it "Browser <host>"). Returns the input key,
+    // or null if it couldn't be found afterwards.
+    private async addBrowserInputNamed(
+        url: string,
+        host: string,
+        name: string
+    ): Promise<string | null> {
+        await this.AddBrowserInput(url);
+        const parsed = await this.GetBase();
+        const inputs = parsed?.vmix?.inputs?.input;
+        const list = Array.isArray(inputs) ? inputs : [inputs].filter(Boolean);
+        const match = list.find(
+            (input: any) =>
+                input?.type === 'Browser' &&
+                input?.title === `Browser ${host}`
+        );
+        if (!match) return null;
+        await this.RenameInput(match.key, name);
+        return match.key;
+    }
+
+    async AddLiveCaptionsInput(): Promise<void> {
+        const key = await this.addBrowserInputNamed(
+            'http://127.0.0.1:3000/',
+            '127.0.0.1',
+            'Live Captions'
+        );
+        if (!key) throw new Error('Could not find the new Live Captions input');
+    }
+
+    async AddAudienceDisplayInput(): Promise<void> {
+        const key = await this.addBrowserInputNamed(
+            'http://10.0.100.5/AudienceDisplay',
+            '10.0.100.5',
+            'Audience Display'
+        );
+        if (!key)
+            throw new Error('Could not find the new Audience Display input');
+        await this.SetInputAudioAlwaysOn(key);
+    }
+
     async GetBase(): Promise<any> {
         return fetch(`${this.settings.baseUrl}`, {
             headers: this.createHeaders(),
@@ -210,6 +368,17 @@ export default class VmixService {
     async isRecording(): Promise<boolean> {
         return this.GetBase().then((parsed) => {
             return parsed.vmix.recording['#text'] === 'True';
+        });
+    }
+
+    async isStreaming(): Promise<boolean> {
+        return this.GetBase().then((parsed) => {
+            // vMix reports streaming the same shape as recording. It exposes
+            // on/off only - never the key/URL or bandwidth.
+            const s = parsed?.vmix?.streaming;
+            if (s === undefined || s === null) return false;
+            const text = typeof s === 'object' ? s['#text'] : s;
+            return text === 'True' || text === true;
         });
     }
 

--- a/src/utils/recording.ts
+++ b/src/utils/recording.ts
@@ -6,6 +6,15 @@ import { getStore } from '../main/store';
 
 export type FileNameMode = 'in-season' | 'off-season';
 
+// In an 8-alliance double elimination bracket, FMS numbers the 13 elimination
+// matches 1-13 and the finals from 14 up. Shared so file naming and FMS result
+// lookups agree on where finals begin.
+export const DOUBLE_ELIM_FINAL_START = 14;
+
+export function isDoubleElimFinal(matchNumber: number): boolean {
+    return matchNumber >= DOUBLE_ELIM_FINAL_START;
+}
+
 const fileNameBuilders: Record<
     FileNameMode,
     (_event: Event | null, _matchStatus: FMSMatchStatus) => string
@@ -21,8 +30,10 @@ const fileNameBuilders: Record<
                 break;
             case 'Playoff':
                 // TODO: Make this more resilient to playoff types other than 8-alliance double elim
-                if (matchStatus.MatchNumber >= 14) {
-                    match = `F1M${matchStatus.MatchNumber - 13}`;
+                if (isDoubleElimFinal(matchStatus.MatchNumber)) {
+                    match = `F1M${
+                        matchStatus.MatchNumber - (DOUBLE_ELIM_FINAL_START - 1)
+                    }`;
                 } else {
                     match = `SF${matchStatus.MatchNumber}M1`;
                 }

--- a/src/utils/recording.ts
+++ b/src/utils/recording.ts
@@ -64,6 +64,26 @@ const fileNameBuilders: Record<
     },
 };
 
+// The per-event folder name recordings are filed into, e.g. "2026 <Event>".
+// Shared so the Auto AV tab shows the same folder attemptRename will create.
+export function eventFolderName(event: Event | null): string {
+    return `${new Date().getFullYear()} ${event?.name ?? 'Unknown Event'}`;
+}
+
+// An example output filename for the given event + naming mode, for showing the
+// user what their files will look like (a Qualification match 1 sample).
+export function sampleFileName(
+    event: Event | null,
+    mode: FileNameMode
+): string {
+    const sample = {
+        Level: 'Qualification',
+        MatchNumber: 1,
+        PlayNumber: 1,
+    } as FMSMatchStatus;
+    return fileNameBuilders[mode](event, sample);
+}
+
 export default async function attemptRename(
     event: Event | null,
     videoLocation: string | null,
@@ -93,26 +113,66 @@ export default async function attemptRename(
                 builder = 'in-season';
             }
 
-            const newFileName = fileNameBuilders[builder](event, matchStatus);
+            // Manual overrides from settings: a typed event name always wins,
+            // and an explicit save folder redirects where files land.
+            const nameOverride = getStore()
+                .get('autoAv.eventNameOverride', '')
+                .trim();
+            const saveFolderOverride = getStore()
+                .get('autoAv.saveFolder', '')
+                .trim();
 
-            // Check if event name folder exists (videoLocation has the file name at the end, so we must "go up" one directory)
+            const effectiveEvent: Event | null = nameOverride
+                ? ({
+                      ...(event ?? {}),
+                      name: nameOverride,
+                      code: nameOverride,
+                  } as Event)
+                : event;
+
+            const newFileName = fileNameBuilders[builder](
+                effectiveEvent,
+                matchStatus
+            );
+
+            // Event-named folder, under the configured save folder if set,
+            // otherwise alongside the vMix recording (videoLocation ends in the
+            // file name, so "../" gives its directory).
+            const baseFolder = saveFolderOverride
+                ? path.resolve(saveFolderOverride)
+                : path.resolve(videoLocation, '../');
             const eventFolder = path.resolve(
-                videoLocation,
-                '../',
-                `${new Date().getFullYear()} ${event?.name ?? 'Unknown Event'}`
+                baseFolder,
+                `${new Date().getFullYear()} ${
+                    effectiveEvent?.name ?? 'Unknown Event'
+                }`
             );
             if (!fs.existsSync(eventFolder)) {
-                fs.mkdirSync(eventFolder);
+                fs.mkdirSync(eventFolder, { recursive: true });
             }
 
-            // Rename and move the file
-            fs.renameSync(
-                path.resolve(videoLocation),
-                path.resolve(eventFolder, newFileName)
-            );
+            const target = path.resolve(eventFolder, newFileName);
+            const source = path.resolve(videoLocation);
+
+            // Rename/move the file; fall back to copy+delete across drives
+            // (renameSync throws EXDEV when the save folder is on another disk).
+            try {
+                fs.renameSync(source, target);
+            } catch (err) {
+                if ((err as { code?: string }).code === 'EXDEV') {
+                    fs.copyFileSync(source, target);
+                    fs.unlinkSync(source);
+                } else {
+                    throw err;
+                }
+            }
+
+            // Remember the real folder so the Auto AV tab can show the exact
+            // path even when no save folder is configured.
+            getStore().set('autoAv.lastSaveFolder', eventFolder);
 
             // Resolve
-            resolve(path.resolve(eventFolder, newFileName));
+            resolve(target);
         } catch (e) {
             reject(e);
         }


### PR DESCRIPTION
## Summary

Reworks the AV Assistant around per-feature tabs and builds out the Auto AV recording pipeline. The app now has a **vMix**, **Live Captions**, and **Auto AV** tab, each sharing a common control row (status dot, version, start/restart/stop, settings), so the three read as one consistent app rather than a menu of loosely related addons.

Tuned live against a real vMix (29.0.0.48) + streaming setup at an event.

## vMix tab

- **Status card**: reachable / recording / streaming at a glance.
- **Stream keys card**: shows whether the key is set for the current event, validates the running keys against the admin hub (cloud) so you can see a mismatch before going live, and a Set stream keys button lives in the card.
- **Connection settings** moved behind a gear dialog (host/port/user/pass).
- **Live streaming bandwidth**: per-stream bitrate plus a combined sparkline, read straight from vMix's own ffmpeg `-report` logs in `C:\ProgramData\vMix\streaming`. Pure Node `fs` (no PowerShell, no background loop): each poll reads the newest per-slot log's tail and takes the last `bitrate=` value verbatim; a stream is "active" if its log grew since the previous poll. Handles up to 5 streams. Spinner stays up until a real reading is ready.
- **Alliance Selection Composite**: one action builds a dedicated vMix input (blank colour base + the existing FMS/AD input as layer 1 + the selected camera as layer 2) sized to the official audience-display camera box, so the camera sits exactly in the AD frame. The operator's own inputs are referenced as layers, not duplicated.
- Default vMix API port corrected from 8000 to **8088** (stock vMix), with a store migration.

## Live Captions tab

- Control row (running state, version, restart, stop) with the caption settings page embedded as an iframe.
- **Hardened child-process management** to fix the recurring blank-screen bug: kills any leftover instance by PID and by whoever holds port 3000 on start, HTTP-probes the server before reporting "running", retries once with a clean port sweep, and cleans up on every quit path. Clicking the version checks for updates.

## Auto AV

- **Per-event manifest**: match state (metadata + cut status) now lives in a `fimav-matches.json` file **in the recording folder**, next to the videos, instead of a single global store. The tab's history simply reflects whatever folder the app is pointed at, so a new event (new folder) starts with a fresh history and the manual "Clear history" button is gone.
- **Dead-time cutting**: after a match records, the app can trim the dead time (keep the match plus the winner animation / results, drop the score-posting gap) and re-encode a clean, upload-ready video. The cut takes the spot in the event folder and the raw original is moved into an `Originals/` subfolder, so the base folder holds every match's final video. Reuses vMix's own `ffmpeg`.
  - Runs **automatically** when enabled (settings toggle, off by default since it re-encodes on the AV machine) or **manually** per match via a Cut button in the new Cut column.
  - Cuts are **queued** so a burst of matches encodes one at a time and never starves vMix/streaming of CPU. A failed cut restores the original.
  - **Matches with a card are never cut** (auto or manual): the card explanation lives in the dead time we would remove, so those are kept whole and shown as "Kept (card)".
- **Recording settings dialog**: event-name override (the shown folder path follows the name immediately), a save folder that is displayed before the first recording (read from vMix's `user.config`), and file-naming style.

## Misc

- Notification bell in the tab bar (with an unread dot) replaces the Alerts menu.
- Removed the now-redundant Addons / Alerts / vMix menus.
- Swept em/en dashes and ellipses out of the UI text.

## Folder layout produced

```
2026 <Event>/
  QM13_<Event>.mp4        cut, or kept whole if the match had a card
  fimav-matches.json      per-event metadata + cut state
  Originals/
    QM13_<Event>.mp4      raw original, for matches that were cut
```

## Testing

Built as a Windows installer and exercised live against vMix + streaming: bandwidth reads match the ffmpeg logs, the composite lands on the AD camera box, live-captions recovers cleanly, and the Auto AV record -> file -> (cut) flow was driven end to end via the FMS emulator.
